### PR TITLE
chore: 배포 healthCheck 엔드포인트 접근 허용

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -84,7 +84,7 @@ jobs:
             sudo docker-compose -f docker-compose-${{env.TARGET_UPSTREAM}}.yml up -d
       
       - name: Check deploy server URL
-        uses: jtalk/url-health-check-action@v3
+        uses: jtalk/url-health-check-action@v4
         with:
           url: http://${{ secrets.AGARANG_SERVER_IP }}:${{env.STOPPED_PORT}}/env
           max-attempts: 5

--- a/src/main/java/com/kuit/agarang/common/config/SecurityConfig.java
+++ b/src/main/java/com/kuit/agarang/common/config/SecurityConfig.java
@@ -1,0 +1,28 @@
+package com.kuit.agarang.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+  @Bean
+  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+
+    http
+      .cors((cors) -> cors.disable()) // 모든 도메인 일시적 허용
+      .csrf((auth) -> auth.disable()) // csrf 일시적 비활성화
+      .formLogin((auth) -> auth.disable()) // 기본 로그인 폼 비활성화
+      .httpBasic((auth) -> auth.disable()); // HTTP 헤더 인증 방식 비활성화
+
+    http
+      .authorizeHttpRequests((auth) -> auth
+        .requestMatchers("/hc", "/env").permitAll());
+
+    return http.build();
+  }
+}


### PR DESCRIPTION
### Descriptions

git action 과정 중 "Check deploy server URL" 에서 오류가 나서 빌드가 중단됐습니다.

시큐리티 설정을 하지 않아 기본 로그인 폼으로 리다이렉트되어 중단된 것이라고 판단해서 시큐리티 설정 후 다시 빌드합니다!

관련 트러블슈팅은 아래 링크에서 확인해주세요!

[CICD 트러블슈팅](https://goo99.notion.site/CICD-Git-Actions-020dcdd7c1d64e70a3f120b616786e34?pvs=4)