### PR TITLE
JPA 도메인 설계

### DIFF
--- a/src/main/java/com/kuit/agarang/AgarangApplication.java
+++ b/src/main/java/com/kuit/agarang/AgarangApplication.java
@@ -2,8 +2,10 @@ package com.kuit.agarang;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class AgarangApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/com/kuit/agarang/common/model/entity/BaseEntity.java
+++ b/src/main/java/com/kuit/agarang/common/model/entity/BaseEntity.java
@@ -1,0 +1,37 @@
+package com.kuit.agarang.common.model.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@SuperBuilder
+@EntityListeners(value = {AuditingEntityListener.class})
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BaseEntity {
+  @CreatedDate
+  @Column(nullable = false, updatable = false)
+  private LocalDateTime createdAt;
+
+  @LastModifiedDate
+  @Column(nullable = false)
+  private LocalDateTime updatedAt;
+
+  private String status = "Active";
+
+  public void changeStatusToInActive() {
+    this.status = "InActive";
+  }
+}

--- a/src/main/java/com/kuit/agarang/common/model/entity/BaseEntity.java
+++ b/src/main/java/com/kuit/agarang/common/model/entity/BaseEntity.java
@@ -1,13 +1,9 @@
 package com.kuit.agarang.common.model.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.experimental.SuperBuilder;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -16,11 +12,10 @@ import java.time.LocalDateTime;
 
 @Getter
 @MappedSuperclass
-@SuperBuilder
 @EntityListeners(value = {AuditingEntityListener.class})
-@AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class BaseEntity {
+
+public abstract class BaseEntity {
   @CreatedDate
   @Column(nullable = false, updatable = false)
   private LocalDateTime createdAt;
@@ -29,9 +24,11 @@ public class BaseEntity {
   @Column(nullable = false)
   private LocalDateTime updatedAt;
 
-  private String status = "Active";
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private Status status = Status.ACTIVE;
 
   public void changeStatusToInActive() {
-    this.status = "InActive";
+    this.status = Status.INACTIVE;
   }
 }

--- a/src/main/java/com/kuit/agarang/common/model/entity/Status.java
+++ b/src/main/java/com/kuit/agarang/common/model/entity/Status.java
@@ -1,0 +1,5 @@
+package com.kuit.agarang.common.model.entity;
+
+public enum Status {
+  ACTIVE, INACTIVE
+}

--- a/src/main/java/com/kuit/agarang/domain/baby/model/entity/Baby.java
+++ b/src/main/java/com/kuit/agarang/domain/baby/model/entity/Baby.java
@@ -2,18 +2,12 @@ package com.kuit.agarang.domain.baby.model.entity;
 
 import com.kuit.agarang.common.model.entity.BaseEntity;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.experimental.SuperBuilder;
+import lombok.*;
 
 import java.time.LocalDate;
 
 @Entity
 @Getter
-@SuperBuilder
-@AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Baby extends BaseEntity {
 
@@ -22,11 +16,19 @@ public class Baby extends BaseEntity {
   private Long id;
 
   @OneToOne(fetch = FetchType.LAZY)
-  @JoinColumn
+  @JoinColumn(name = "character_id")
   private Character character;
 
   private String code;
   private String name;
-  private LocalDate date; // 출산 예정일
+  private LocalDate expectedDueAt; // 출산 예정일
   private Double weight;
+
+  @Builder
+  public Baby(String code, String name, LocalDate expectedDueAt, Double weight) {
+    this.code = code;
+    this.name = name;
+    this.expectedDueAt = expectedDueAt;
+    this.weight = weight;
+  }
 }

--- a/src/main/java/com/kuit/agarang/domain/baby/model/entity/Baby.java
+++ b/src/main/java/com/kuit/agarang/domain/baby/model/entity/Baby.java
@@ -1,0 +1,32 @@
+package com.kuit.agarang.domain.baby.model.entity;
+
+import com.kuit.agarang.common.model.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@SuperBuilder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Baby extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @OneToOne(fetch = FetchType.LAZY)
+  @JoinColumn
+  private Character character;
+
+  private String code;
+  private String name;
+  private LocalDate date; // 출산 예정일
+  private Double weight;
+}

--- a/src/main/java/com/kuit/agarang/domain/baby/model/entity/Character.java
+++ b/src/main/java/com/kuit/agarang/domain/baby/model/entity/Character.java
@@ -1,0 +1,27 @@
+package com.kuit.agarang.domain.baby.model.entity;
+
+import com.kuit.agarang.common.model.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Getter
+@SuperBuilder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "characters") // character : 예약어
+public class Character extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  private String name;
+  private String description;
+  private String imageUrl;
+
+}

--- a/src/main/java/com/kuit/agarang/domain/baby/model/entity/Character.java
+++ b/src/main/java/com/kuit/agarang/domain/baby/model/entity/Character.java
@@ -3,17 +3,14 @@ package com.kuit.agarang.domain.baby.model.entity;
 import com.kuit.agarang.common.model.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.experimental.SuperBuilder;
 
 @Entity
 @Getter
-@SuperBuilder
-@AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "characters") // character : 예약어
+@Table(name = "`character`") // character : 예약어
 public class Character extends BaseEntity {
 
   @Id
@@ -24,4 +21,10 @@ public class Character extends BaseEntity {
   private String description;
   private String imageUrl;
 
+  @Builder
+  public Character(String name, String description, String imageUrl) {
+    this.name = name;
+    this.description = description;
+    this.imageUrl = imageUrl;
+  }
 }

--- a/src/main/java/com/kuit/agarang/domain/member/model/entity/Member.java
+++ b/src/main/java/com/kuit/agarang/domain/member/model/entity/Member.java
@@ -3,16 +3,11 @@ package com.kuit.agarang.domain.member.model.entity;
 import com.kuit.agarang.common.model.entity.BaseEntity;
 import com.kuit.agarang.domain.baby.model.entity.Baby;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import lombok.experimental.SuperBuilder;
 
 @Entity
 @Getter
-@SuperBuilder
-@AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends BaseEntity {
 
@@ -21,12 +16,17 @@ public class Member extends BaseEntity {
   private Long id;
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn
+  @JoinColumn(name = "baby_id")
   private Baby baby;
 
   @OneToOne(fetch = FetchType.LAZY)
-  @JoinColumn
+  @JoinColumn(name = "refresh_token_id")
   private RefreshToken refreshToken;
 
   private String role;
+
+  @Builder
+  public Member(String role) {
+    this.role = role;
+  }
 }

--- a/src/main/java/com/kuit/agarang/domain/member/model/entity/Member.java
+++ b/src/main/java/com/kuit/agarang/domain/member/model/entity/Member.java
@@ -1,0 +1,32 @@
+package com.kuit.agarang.domain.member.model.entity;
+
+import com.kuit.agarang.common.model.entity.BaseEntity;
+import com.kuit.agarang.domain.baby.model.entity.Baby;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Getter
+@SuperBuilder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn
+  private Baby baby;
+
+  @OneToOne(fetch = FetchType.LAZY)
+  @JoinColumn
+  private RefreshToken refreshToken;
+
+  private String role;
+}

--- a/src/main/java/com/kuit/agarang/domain/member/model/entity/RefreshToken.java
+++ b/src/main/java/com/kuit/agarang/domain/member/model/entity/RefreshToken.java
@@ -1,17 +1,14 @@
 package com.kuit.agarang.domain.member.model.entity;
 
 import com.kuit.agarang.common.model.entity.BaseEntity;
-import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.experimental.SuperBuilder;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.*;
 
 @Entity
 @Getter
-@SuperBuilder
-@AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RefreshToken extends BaseEntity {
 
@@ -20,4 +17,9 @@ public class RefreshToken extends BaseEntity {
   private Long id;
 
   private String value;
+
+  @Builder
+  public RefreshToken(String value) {
+    this.value = value;
+  }
 }

--- a/src/main/java/com/kuit/agarang/domain/member/model/entity/RefreshToken.java
+++ b/src/main/java/com/kuit/agarang/domain/member/model/entity/RefreshToken.java
@@ -1,0 +1,23 @@
+package com.kuit.agarang.domain.member.model.entity;
+
+import com.kuit.agarang.common.model.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Getter
+@SuperBuilder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshToken extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  private String value;
+}

--- a/src/main/java/com/kuit/agarang/domain/memory/model/entity/Hashtag.java
+++ b/src/main/java/com/kuit/agarang/domain/memory/model/entity/Hashtag.java
@@ -2,16 +2,10 @@ package com.kuit.agarang.domain.memory.model.entity;
 
 import com.kuit.agarang.common.model.entity.BaseEntity;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.experimental.SuperBuilder;
+import lombok.*;
 
 @Entity
 @Getter
-@SuperBuilder
-@AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Hashtag extends BaseEntity {
 
@@ -20,8 +14,13 @@ public class Hashtag extends BaseEntity {
   private Long id;
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn
+  @JoinColumn(name = "memory_id")
   private Memory memory;
 
   private String name; // 해시태그 명
+
+  @Builder
+  public Hashtag(String name) {
+    this.name = name;
+  }
 }

--- a/src/main/java/com/kuit/agarang/domain/memory/model/entity/Hashtag.java
+++ b/src/main/java/com/kuit/agarang/domain/memory/model/entity/Hashtag.java
@@ -1,0 +1,27 @@
+package com.kuit.agarang.domain.memory.model.entity;
+
+import com.kuit.agarang.common.model.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Getter
+@SuperBuilder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Hashtag extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn
+  private Memory memory;
+
+  private String name; // 해시태그 명
+}

--- a/src/main/java/com/kuit/agarang/domain/memory/model/entity/Memory.java
+++ b/src/main/java/com/kuit/agarang/domain/memory/model/entity/Memory.java
@@ -1,0 +1,39 @@
+package com.kuit.agarang.domain.memory.model.entity;
+
+
+import com.kuit.agarang.common.model.entity.BaseEntity;
+import com.kuit.agarang.domain.baby.model.entity.Baby;
+import com.kuit.agarang.domain.member.model.entity.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Getter
+@SuperBuilder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Memory extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn
+  private Member member;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn
+  private Baby baby;
+
+  private String imageUrl;
+  private String text;
+  private String genre;
+  private String mood;
+  private String tempo;
+  private String instrumentType;
+}

--- a/src/main/java/com/kuit/agarang/domain/memory/model/entity/Memory.java
+++ b/src/main/java/com/kuit/agarang/domain/memory/model/entity/Memory.java
@@ -4,17 +4,15 @@ package com.kuit.agarang.domain.memory.model.entity;
 import com.kuit.agarang.common.model.entity.BaseEntity;
 import com.kuit.agarang.domain.baby.model.entity.Baby;
 import com.kuit.agarang.domain.member.model.entity.Member;
+import com.kuit.agarang.domain.memory.model.entity.enums.Genre;
+import com.kuit.agarang.domain.memory.model.entity.enums.Instrument;
+import com.kuit.agarang.domain.memory.model.entity.enums.Mood;
+import com.kuit.agarang.domain.memory.model.entity.enums.Tempo;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.experimental.SuperBuilder;
+import lombok.*;
 
 @Entity
 @Getter
-@SuperBuilder
-@AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Memory extends BaseEntity {
 
@@ -23,17 +21,36 @@ public class Memory extends BaseEntity {
   private Long id;
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn
+  @JoinColumn(name = "member_id")
   private Member member;
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn
+  @JoinColumn(name = "baby_id")
   private Baby baby;
 
   private String imageUrl;
   private String text;
-  private String genre;
-  private String mood;
-  private String tempo;
-  private String instrumentType;
+
+  @Enumerated(EnumType.STRING)
+  private Genre genre;
+
+  @Enumerated(EnumType.STRING)
+  private Mood mood;
+
+  @Enumerated(EnumType.STRING)
+  private Tempo tempo;
+
+  @Enumerated(EnumType.STRING)
+  private Instrument instrument;
+
+  @Builder
+  public Memory(String imageUrl, String text, Genre genre,
+                Mood mood, Tempo tempo, Instrument instrument) {
+    this.imageUrl = imageUrl;
+    this.text = text;
+    this.genre = genre;
+    this.mood = mood;
+    this.tempo = tempo;
+    this.instrument = instrument;
+  }
 }

--- a/src/main/java/com/kuit/agarang/domain/memory/model/entity/MemoryBookmark.java
+++ b/src/main/java/com/kuit/agarang/domain/memory/model/entity/MemoryBookmark.java
@@ -1,0 +1,30 @@
+package com.kuit.agarang.domain.memory.model.entity;
+
+import com.kuit.agarang.common.model.entity.BaseEntity;
+import com.kuit.agarang.domain.member.model.entity.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Getter
+@SuperBuilder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemoryBookmark extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn
+  private Member member;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn
+  private Memory memory;
+}

--- a/src/main/java/com/kuit/agarang/domain/memory/model/entity/MemoryBookmark.java
+++ b/src/main/java/com/kuit/agarang/domain/memory/model/entity/MemoryBookmark.java
@@ -3,16 +3,10 @@ package com.kuit.agarang.domain.memory.model.entity;
 import com.kuit.agarang.common.model.entity.BaseEntity;
 import com.kuit.agarang.domain.member.model.entity.Member;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.experimental.SuperBuilder;
+import lombok.*;
 
 @Entity
 @Getter
-@SuperBuilder
-@AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MemoryBookmark extends BaseEntity {
 
@@ -21,10 +15,10 @@ public class MemoryBookmark extends BaseEntity {
   private Long id;
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn
+  @JoinColumn(name = "member_id")
   private Member member;
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn
+  @JoinColumn(name = "memory_id")
   private Memory memory;
 }

--- a/src/main/java/com/kuit/agarang/domain/memory/model/entity/MusicBookmark.java
+++ b/src/main/java/com/kuit/agarang/domain/memory/model/entity/MusicBookmark.java
@@ -3,16 +3,10 @@ package com.kuit.agarang.domain.memory.model.entity;
 import com.kuit.agarang.common.model.entity.BaseEntity;
 import com.kuit.agarang.domain.member.model.entity.Member;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.experimental.SuperBuilder;
+import lombok.*;
 
 @Entity
 @Getter
-@SuperBuilder
-@AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MusicBookmark extends BaseEntity {
 
@@ -21,10 +15,10 @@ public class MusicBookmark extends BaseEntity {
   private Long id;
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn
+  @JoinColumn(name = "member_id")
   private Member member;
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn
+  @JoinColumn(name = "memory_id")
   private Memory memory;
 }

--- a/src/main/java/com/kuit/agarang/domain/memory/model/entity/MusicBookmark.java
+++ b/src/main/java/com/kuit/agarang/domain/memory/model/entity/MusicBookmark.java
@@ -1,0 +1,30 @@
+package com.kuit.agarang.domain.memory.model.entity;
+
+import com.kuit.agarang.common.model.entity.BaseEntity;
+import com.kuit.agarang.domain.member.model.entity.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Getter
+@SuperBuilder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MusicBookmark extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn
+  private Member member;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn
+  private Memory memory;
+}

--- a/src/main/java/com/kuit/agarang/domain/memory/model/entity/enums/Genre.java
+++ b/src/main/java/com/kuit/agarang/domain/memory/model/entity/enums/Genre.java
@@ -1,0 +1,5 @@
+package com.kuit.agarang.domain.memory.model.entity.enums;
+
+public enum Genre {
+  BALLAD, POP, JAZZ, ACOUSTIC, RNB, ELECTRONIC, ROCK, INDIE, HIPHOP
+}

--- a/src/main/java/com/kuit/agarang/domain/memory/model/entity/enums/Instrument.java
+++ b/src/main/java/com/kuit/agarang/domain/memory/model/entity/enums/Instrument.java
@@ -1,0 +1,6 @@
+package com.kuit.agarang.domain.memory.model.entity.enums;
+
+public enum Instrument {
+  PIANO, VIOLIN, FLUTE, CLARINET, BASE_GUITAR, ELECTRIC_GUITAR,
+  HARP, TRUMPET, SAXOPHONE, VIOLA, CELLO, XYLOPHONE
+}

--- a/src/main/java/com/kuit/agarang/domain/memory/model/entity/enums/Mood.java
+++ b/src/main/java/com/kuit/agarang/domain/memory/model/entity/enums/Mood.java
@@ -1,0 +1,5 @@
+package com.kuit.agarang.domain.memory.model.entity.enums;
+
+public enum Mood {
+  BEAUTIFUL, BRIGHT, HAPPY, PEACEFUL, WARM, ENERGETIC, FANTASTIC, LOVELY, TOUCHING
+}

--- a/src/main/java/com/kuit/agarang/domain/memory/model/entity/enums/Tempo.java
+++ b/src/main/java/com/kuit/agarang/domain/memory/model/entity/enums/Tempo.java
@@ -1,0 +1,5 @@
+package com.kuit.agarang.domain.memory.model.entity.enums;
+
+public enum Tempo {
+  Fast, MID, SLOW
+}

--- a/src/main/java/com/kuit/agarang/domain/playlist/model/entity/MemoryPlaylist.java
+++ b/src/main/java/com/kuit/agarang/domain/playlist/model/entity/MemoryPlaylist.java
@@ -3,16 +3,10 @@ package com.kuit.agarang.domain.playlist.model.entity;
 import com.kuit.agarang.common.model.entity.BaseEntity;
 import com.kuit.agarang.domain.memory.model.entity.Memory;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.experimental.SuperBuilder;
+import lombok.*;
 
 @Entity
 @Getter
-@SuperBuilder
-@AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MemoryPlaylist extends BaseEntity {
 
@@ -21,10 +15,10 @@ public class MemoryPlaylist extends BaseEntity {
   private Long id;
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn
+  @JoinColumn(name = "playlist_id")
   private Playlist playlist;
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn
+  @JoinColumn(name = "memory_id")
   private Memory memory;
 }

--- a/src/main/java/com/kuit/agarang/domain/playlist/model/entity/MemoryPlaylist.java
+++ b/src/main/java/com/kuit/agarang/domain/playlist/model/entity/MemoryPlaylist.java
@@ -1,0 +1,30 @@
+package com.kuit.agarang.domain.playlist.model.entity;
+
+import com.kuit.agarang.common.model.entity.BaseEntity;
+import com.kuit.agarang.domain.memory.model.entity.Memory;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Getter
+@SuperBuilder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemoryPlaylist extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn
+  private Playlist playlist;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn
+  private Memory memory;
+}

--- a/src/main/java/com/kuit/agarang/domain/playlist/model/entity/Playlist.java
+++ b/src/main/java/com/kuit/agarang/domain/playlist/model/entity/Playlist.java
@@ -5,16 +5,11 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import lombok.experimental.SuperBuilder;
 
 @Entity
 @Getter
-@SuperBuilder
-@AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Playlist extends BaseEntity {
 
@@ -23,5 +18,11 @@ public class Playlist extends BaseEntity {
   private Long id;
 
   private String name;
-  private String imageUrl; // 플레이리스트 이미지
+  private String imageUrl;
+
+  @Builder
+  public Playlist(String name, String imageUrl) {
+    this.name = name;
+    this.imageUrl = imageUrl;
+  }
 }

--- a/src/main/java/com/kuit/agarang/domain/playlist/model/entity/Playlist.java
+++ b/src/main/java/com/kuit/agarang/domain/playlist/model/entity/Playlist.java
@@ -1,0 +1,27 @@
+package com.kuit.agarang.domain.playlist.model.entity;
+
+import com.kuit.agarang.common.model.entity.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Getter
+@SuperBuilder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Playlist extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  private String name;
+  private String imageUrl; // 플레이리스트 이미지
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #8 JPA 도메인 설계

## 📝작업 내용

> JPA 도메인 설계 
- BaseEntity (createdAt, updatedAt, status) 
=> 공통속성은 BaseEntity 클래스를 만들어 따로 관리하고, 이를 상속받도록 구현했습니다

- ERD 기반 엔티티 생성 

### 스크린샷 (선택)

![image](https://github.com/KUIT-AGARANG/Agarang-Backend/assets/141808008/d1427c2c-26b5-4116-850c-9327487382c6)


## 💬리뷰 요구사항(선택)

- application.yml, HealthCheckController 파일을 주석처리한 뒤, MySQL 로컬DB 로 생성 확인 했습니다. 

- JPA 양방향 매핑? -> 일단 단방향으로 하고, 필요시 추가하는 방향으로 고려하겠습니다. 일단 단방향으로만 했습니다 

- Member 테이블이 RefreshTokenId를 FK로 관리하도록 수정
=> 더 자주 조회되는 쪽에 FK로 설정하는게 권장된다고 해서 바꿔놨습니다
