### PR TITLE
[CICD] develop push 시 자동 배포

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -3,8 +3,6 @@ name: CICD
 on:
   push:
     branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
 
 permissions:
   contents: read

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -2,7 +2,9 @@ name: CICD
 
 on:
   push:
-    branches: [ "main" ]
+    branches:
+      - "main"
+      - "develop"
 
 permissions:
   contents: read


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

develop push 시 에도 깃액션이 동작하게 설정하여 재배포를 진행합니다.

단일 서버라서 유저가 사용하고 있는 서버는 main 브랜치 내용만 유지하는 것이 맞지만
발표까지 개발 기간이 짧은 점, ai 콜백 기능을 구현하려면 local 은 한계가 있는 점 등을 고려하여 

초기 개발 단계 기간동안은 서버에 develop 의 최신상태를 유지하는 것이 어떤지 제안합니다!
