### PR TITLE
[Feature] AWS S3 단일 파일 업로드

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,9 @@ dependencies {
     // WebClient for HTTP AI API
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'io.netty:netty-resolver-dns-native-macos:4.1.68.Final:osx-aarch_64'
+    // S3
+    implementation platform("software.amazon.awssdk:bom:2.26.20")
+    implementation 'software.amazon.awssdk:s3'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/kuit/agarang/global/s3/config/S3Config.java
+++ b/src/main/java/com/kuit/agarang/global/s3/config/S3Config.java
@@ -1,0 +1,27 @@
+package com.kuit.agarang.global.s3.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class S3Config {
+
+  @Value("${aws.credentials.accessKey}")
+  private String accessKey;
+  @Value("${aws.credentials.secretKey}")
+  private String secretKey;
+
+  @Bean
+  public S3Client amazonS3Client() {
+    AwsBasicCredentials awsCredentials = AwsBasicCredentials.create(accessKey, secretKey);
+    return S3Client.builder()
+      .region(Region.AP_NORTHEAST_2)
+      .credentialsProvider(StaticCredentialsProvider.create(awsCredentials))
+      .build();
+  }
+}

--- a/src/main/java/com/kuit/agarang/global/s3/model/enums/FileCategory.java
+++ b/src/main/java/com/kuit/agarang/global/s3/model/enums/FileCategory.java
@@ -1,0 +1,12 @@
+package com.kuit.agarang.global.s3.model.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum FileCategory {
+  MEMORY("memory/"), MUSIC("music/");
+
+  private final String path;
+}

--- a/src/main/java/com/kuit/agarang/global/s3/utils/S3Util.java
+++ b/src/main/java/com/kuit/agarang/global/s3/utils/S3Util.java
@@ -1,0 +1,94 @@
+package com.kuit.agarang.global.s3.utils;
+
+import com.kuit.agarang.global.s3.model.enums.FileCategory;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class S3Util {
+
+  private final S3Client s3Client;
+  @Value("${aws.s3.bucket}")
+  private String bucket;
+  @Value("${aws.s3.upload.tmpPath}")
+  private String tmpPath;
+
+  public String upload(MultipartFile file, FileCategory category) throws IOException {
+    log.info("S3 파일 업로드가 시작되었습니다. [{} of {}]", file.getOriginalFilename(), category);
+
+    File convertedFile = convert(file, category)
+      .orElseThrow(() -> new RuntimeException("파일 변환에 실패했습니다."));
+
+    try {
+      validateFileExtension(convertedFile);
+
+      String fileName = createFileName(convertedFile, category);
+      PutObjectRequest request = PutObjectRequest.builder()
+        .bucket(bucket)
+        .key(fileName)
+        .contentType(file.getContentType())
+        .contentLength(file.getSize())
+        .build();
+
+      s3Client.putObject(request, RequestBody.fromFile(convertedFile));
+      log.info("S3 파일 업로드가 완료되었습니다. [{} of {}]", fileName, category);
+      return fileName;
+    } catch (S3Exception e) {
+      log.error("AWS S3 통신에 문제가 발생했습니다.");
+      throw new RuntimeException(e.getMessage());
+    } finally {
+      if (convertedFile.exists()) {
+        deleteLocalFile(convertedFile);
+      }
+    }
+  }
+
+  private void deleteLocalFile(File localFile) {
+    if (localFile.delete()) {
+      log.info("임시 업로드 파일이 성공적으로 삭제되었습니다. [{}]", localFile.getName());
+      return;
+    }
+    log.info("임시 업로드 파일 삭제를 실패했습니다.");
+  }
+
+  private Optional<File> convert(MultipartFile file, FileCategory category) throws IOException {
+    File convertedFile = new File(tmpPath + category.getPath() + file.getOriginalFilename());
+    if (convertedFile.createNewFile()) {
+      try (FileOutputStream fos = new FileOutputStream(convertedFile)) {
+        fos.write(file.getBytes());
+      }
+      return Optional.of(convertedFile);
+    }
+    return Optional.empty();
+  }
+
+  private String createFileName(File file, FileCategory fileCategory) {
+    return fileCategory.getPath() + UUID.randomUUID() + "_" + file.getName();
+  }
+
+  private void validateFileExtension(File file) {
+    String fileExtension = file.getName().substring(file.getName().lastIndexOf(".") + 1).toLowerCase();
+    List<String> allowedExtensions = Arrays.asList("jpg", "png", "jpeg", "mp3");
+
+    if (!allowedExtensions.contains(fileExtension)) {
+      throw new RuntimeException("지원하지 않는 파일확장자입니다.");
+    }
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,11 +5,11 @@ spring:
 ---
 spring:
   profiles:
-    active: blue
+    active: local
     group:
       local: local, common, secret
-      blue: blue, common, secret
-      green: green, common, secret
+      blue: blue, common, secret, server-common
+      green: green, common, secret, server-common
 
 server:
   env: blue
@@ -26,6 +26,11 @@ server:
 serverAddress: localhost
 serverName: local_server
 
+aws:
+  s3:
+    upload:
+      tmpPath: ./s3-uploads/
+
 ---
 spring:
   config:
@@ -35,7 +40,6 @@ spring:
 server:
   port: 8080
 
-serverAddress: 43.200.109.115
 serverName: blue_server
 
 ---
@@ -47,8 +51,20 @@ spring:
 server:
   port: 8081
 
-serverAddress: 43.200.109.115
 serverName: green_server
+
+---
+spring:
+  config:
+    activate:
+      on-profile: server-common
+
+serverAddress: 43.200.109.115
+
+aws:
+  s3:
+    upload:
+      tmpPath: /var/app/s3-uploads/
 
 ---
 spring:
@@ -64,3 +80,7 @@ spring:
         show_sql: true
         format_sql: true
     open-in-view: true
+  servlet:
+    multipart: # TODO: Exception Handler 추가하기
+      max-file-size: 5MB
+      max-request-size: 10MB


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#17 

<br/>

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

S3 에 이미지(jpg, jpeg, png)와 음악(mp3) 단일 파일을 업로드 합니다.

```
1. Memory 관련 이미지 저장 요청 (max 5MB)

2. 파일 확장자 검사 (jpg, jpeg, png, mp3 허용)

3. ec2 서버 /var/app/s3-uploads/memory 에 임시 저장
ps) 로컬인 경우 s3-uploads/memory 에 저장됩니다.

4. s3 버킷의 memory 파일에 저장 (put)

5. 업로드 완료 시 /var/app/s3-uploads/memory 에 임시 저장된 파일 삭제
```

> Q. 음악인 경우는?

A. 음악이면 music 디렉토리에 저장됩니다.

> Q. 임시 저장하는 이유는?

A. 가장 큰 이유는 안정성입니다. 임시 파일을 먼저 저장하는 과정을 통해서 파일의 유효성을 검증하고, 이후 네트워크 문제로 s3 업로드 실패할 경우에 재시도 로직을 추가하는 등의 과정을 추가할 수 있습니다.
혹은, 임시 저장 후 비동기로 s3 에 저장하는 등의 방법도 고려중입니다.

> Q. 파일이름을 `createFileName()` 으로 다시 생성하는 이유는?

A. s3 에 저장되는 파일이름은 get 할 때 key 값으로 활용됩니다. 따라서 UUID 와 파일의 이름을 활용하여 파일이름을 새롭게 커스텀합니다.

> Q. 여러개 파일을 저장해야 할 때는?

A. 현재는 단일 파일 업로드만 필요해서 구현하지 않았고, 이후 여러 파일을 저장해야 할 경우를 대비해서 메서드를 분리했습니다. 여러개 파일 업로드는 for 문 안에서 각 파일에 대해 기존 메서드를 가져다 사용할 예정입니다.

<br/>

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

s3 콘솔에서는 업로드 테스트 완료했습니다! 이제 슬슬 테스트 코드도 짜볼게요..!!!
현재 로직은 jpg/jpeg/png/mp3 가 아닌 파일은 exception 을 던집니다. 확장자는 어디까지 허용할지 더 얘기해봐요!
