### PR TITLE
[Infra] 서버 환경설정 파일 분리 및 gitignore 처리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ out/
 
 ### VS Code ###
 .vscode/
+
+src/main/resources/application-secret.yml
+src/main/resources/application-secret-prod.yml
+src/test/resources/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,4 @@ ARG JAR_FILE=build/libs/*.jar
 ARG PROFILES
 ARG ENV
 COPY ${JAR_FILE} app.jar
-ENTRYPOINT ["java", "-Dspring.profiles.active=${PROFILES}", "-Dserver.env=${ENV}", "-jar", "/app.jar"]
+ENTRYPOINT ["java", "-Dspring.profiles.active=${PROFILES}", "-jar", "/app.jar"]

--- a/src/main/java/com/kuit/agarang/global/deploy/controller/HealthCheckController.java
+++ b/src/main/java/com/kuit/agarang/global/deploy/controller/HealthCheckController.java
@@ -18,15 +18,6 @@ public class HealthCheckController {
   @Value("${deploy.name}")
   private String serverName;
 
-  @GetMapping("/hc")
-  public ResponseEntity<ServerInfo> healthCheck() {
-    return ResponseEntity.ok(ServerInfo.builder()
-      .port(serverPort)
-      .address(serverAddress)
-      .name(serverName)
-      .build());
-  }
-
   @GetMapping("/env")
   public ResponseEntity<String> getEnv() {
     return ResponseEntity.ok(env);

--- a/src/main/java/com/kuit/agarang/global/deploy/controller/HealthCheckController.java
+++ b/src/main/java/com/kuit/agarang/global/deploy/controller/HealthCheckController.java
@@ -9,13 +9,13 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class HealthCheckController {
 
-  @Value("${server.env}")
+  @Value("${deploy.env}")
   private String env;
   @Value("${server.port}")
   private String serverPort;
-  @Value("${serverAddress}")
+  @Value("${deploy.address}")
   private String serverAddress;
-  @Value("${serverName}")
+  @Value("${deploy.name}")
   private String serverName;
 
   @GetMapping("/hc")

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,18 @@
+spring:
+  config:
+    activate:
+      on-profile: local
+  jpa:
+    defer-datasource-initialization: true # Sql auto init after jpa ddl-auto operation
+  sql: # Set src/main/resources/data.sql auto init
+    init:
+      mode: always
+      data-locations: classpath:data.sql
+
+deploy:
+  env: local
+  address: localhost
+  name: local_server
+
+server:
+  port: 8080

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,27 @@
+server:
+  port: 8080
+
+---
+
+spring:
+  config:
+    activate:
+      on-profile: blue
+
+server:
+  port: 8080
+deploy:
+  env: blue
+  name: blue_server
+
+---
+spring:
+  config:
+    activate:
+      on-profile: green
+
+server:
+  port: 8081
+deploy:
+  env: green
+  name: green_server

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,66 +1,15 @@
 spring:
   application:
     name: agarang
-
----
-spring:
+  config:
+    import: classpath:application-prod.yml
   profiles:
     active: local
     group:
-      local: local, common, secret
-      blue: blue, common, secret, server-common
-      green: green, common, secret, server-common
+      local: local, secret
+      blue: blue, secret
+      green: green, secret
 
-server:
-  env: blue
-
----
-spring:
-  config:
-    activate:
-      on-profile: local
-
-server:
-  port: 8080
-
-serverAddress: localhost
-serverName: local_server
-
----
-spring:
-  config:
-    activate:
-      on-profile: blue
-
-server:
-  port: 8080
-
-serverName: blue_server
-
----
-spring:
-  config:
-    activate:
-      on-profile: green
-
-server:
-  port: 8081
-
-serverName: green_server
-
----
-spring:
-  config:
-    activate:
-      on-profile: server-common
-
-serverAddress: 43.200.109.115
-
----
-spring:
-  config:
-    activate:
-      on-profile: common
   jpa:
     generate-ddl: true
     hibernate:
@@ -74,8 +23,3 @@ spring:
     multipart: # TODO: Exception Handler 추가하기
       max-file-size: 5MB
       max-request-size: 10MB
-
-aws:
-  s3:
-    upload:
-      tempPath: ./temp/


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#25 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### ✅application.yml 분리

#### 1. application.yml
- 위 파일이 기본적으로 실행됩니다.
- profile을 `local`, `blue,` `green`로 구분하여 사용합니다.
- local의 경우 공개 가능한 local 설정 파일인 application-local.yml과 공개 불가능한 application-secret.yml을 사용합니다.

#### 2. application-local.yml
- local의 공통적인 정보가 저장됩니다.
- 기본적인 서버 설정값(env, address, name, port)가 기본값으로 설정됩니다.

#### 3. application-prod.yml
- prod라는 profile은 없지만, 공개 가능한 배포 관련 정보가 모여있습니다.
- blue와 green profile에 대한 정보가 모여있습니다.(분리하는게 오히려 난잡한거 같아서 둘은 "배포"라는 하나의 뜻으로 묶었습니다)
- blue와 green일때에 맞게 env, name, port가 설정됩니다.
- address의 경우 `application-secret.yml`에 작성됩니다.(IP유출 방지)

#### 4. application-secret.yml(오프라인 공유)
- Datasource, API Key 등의 공개 불가능한 정보가 있습니다.
- 로컬 작업시에는 필요한 application-secret.yml을 생성하여 사용합니다.
- 배포할 시 필요한 application-secret.yml을 CI과정 간 추가 생성해주어야합니다.(현재와 같이)
- 로컬에서 사용하는 secret 파일과 배포시에 사용하는 secret파일은 datasource와 deploy.address정보의 유무 차이입니다.(노션 참고)

### ✅환경변수로 `env` 주입 의존성 제거
- env를 주입하지 않아도 `blue`, `green` profile 설정 시 env가 자동으로 설정됩니다.
- 혹시 이 부분에 문제가 있다면 말씀해주세요!

### ✅환경변수 수정
- serverName -> deploy.name
- serverAddress -> deploy.address
- env -> deploy.env
- 관련해서 `HealthCheckController`에서 주입할 때도 수정했습니다.

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

로컬에서 동작 시 어떤 프로파일이든 정상 동작하는거 확인했습니다.
도커로 배포 시 환경변수가 잘 설정되는지 확인 부탁드립니다!

추가로 env내용 제거한 부분이 영향이 있는지 확인 부탁드려요!