### PR TITLE
[Feat] 서버 에러로그 발생 시 디스코드 알림 연동

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ configurations {
 
 repositories {
     mavenCentral()
+    maven { url 'https://jitpack.io' }
 }
 
 dependencies {
@@ -48,6 +49,8 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
+    // Discord Logs
+    implementation 'com.github.napstr:logback-discord-appender:1.0.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/kuit/agarang/global/common/config/ProdWebConfig.java
+++ b/src/main/java/com/kuit/agarang/global/common/config/ProdWebConfig.java
@@ -1,0 +1,21 @@
+package com.kuit.agarang.global.common.config;
+
+import com.kuit.agarang.global.discord.interceptor.ProdErrorInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Profile("!local")
+@Configuration
+@RequiredArgsConstructor
+public class ProdWebConfig implements WebMvcConfigurer {
+
+  private final ProdErrorInterceptor prodErrorInterceptor;
+
+  @Override
+  public void addInterceptors(InterceptorRegistry registry) {
+    registry.addInterceptor(prodErrorInterceptor);
+  }
+}

--- a/src/main/java/com/kuit/agarang/global/discord/interceptor/ProdErrorInterceptor.java
+++ b/src/main/java/com/kuit/agarang/global/discord/interceptor/ProdErrorInterceptor.java
@@ -1,0 +1,28 @@
+package com.kuit.agarang.global.discord.interceptor;
+
+import com.kuit.agarang.global.discord.model.dto.HeaderInfo;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.MDC;
+import org.springframework.context.annotation.Profile;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Profile("!local")
+@Component
+public class ProdErrorInterceptor implements HandlerInterceptor {
+
+  @Override
+  public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, @Nullable Exception ex) throws Exception {
+    if (ex != null) {
+      MDC.clear();
+      HeaderInfo headerInfo = HeaderInfo.of(request);
+      MDC.put("host", headerInfo.getHost());
+      MDC.put("cookie", headerInfo.getCookie());
+      MDC.put("method", headerInfo.getMethod());
+      MDC.put("url", headerInfo.getUrl());
+      MDC.put("query", headerInfo.getQueryString());
+    }
+  }
+}

--- a/src/main/java/com/kuit/agarang/global/discord/interceptor/ProdErrorInterceptor.java
+++ b/src/main/java/com/kuit/agarang/global/discord/interceptor/ProdErrorInterceptor.java
@@ -21,7 +21,7 @@ public class ProdErrorInterceptor implements HandlerInterceptor {
       MDC.put("host", headerInfo.getHost());
       MDC.put("cookie", headerInfo.getCookie());
       MDC.put("method", headerInfo.getMethod());
-      MDC.put("url", headerInfo.getUrl());
+      MDC.put("uri", headerInfo.getUri());
       MDC.put("query", headerInfo.getQueryString());
     }
   }

--- a/src/main/java/com/kuit/agarang/global/discord/model/dto/HeaderInfo.java
+++ b/src/main/java/com/kuit/agarang/global/discord/model/dto/HeaderInfo.java
@@ -1,0 +1,40 @@
+package com.kuit.agarang.global.discord.model.dto;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@NoArgsConstructor
+public class HeaderInfo {
+
+  private static final String QUERY_PREFIX = "?";
+
+  private String host;
+  private String cookie;
+  private String method;
+  private String url;
+  private String queryString;
+
+  @Builder
+  public HeaderInfo(String host, String cookie, String method, String url, String queryString) {
+    this.host = host;
+    this.cookie = cookie;
+    this.method = method;
+    this.url = url;
+    this.queryString = queryString;
+  }
+
+  public static HeaderInfo of(HttpServletRequest request) {
+    return HeaderInfo.builder()
+      .host(request.getHeader("host"))
+      .cookie(request.getHeader("cookie"))
+      .method(request.getMethod())
+      .url(request.getRequestURL().toString())
+      .queryString(request.getQueryString() == null ? null : QUERY_PREFIX + request.getQueryString())
+      .build();
+  }
+}

--- a/src/main/java/com/kuit/agarang/global/discord/model/dto/HeaderInfo.java
+++ b/src/main/java/com/kuit/agarang/global/discord/model/dto/HeaderInfo.java
@@ -16,15 +16,15 @@ public class HeaderInfo {
   private String host;
   private String cookie;
   private String method;
-  private String url;
+  private String uri;
   private String queryString;
 
   @Builder
-  public HeaderInfo(String host, String cookie, String method, String url, String queryString) {
+  public HeaderInfo(String host, String cookie, String method, String uri, String queryString) {
     this.host = host;
     this.cookie = cookie;
     this.method = method;
-    this.url = url;
+    this.uri = uri;
     this.queryString = queryString;
   }
 
@@ -33,7 +33,7 @@ public class HeaderInfo {
       .host(request.getHeader("host"))
       .cookie(request.getHeader("cookie"))
       .method(request.getMethod())
-      .url(request.getRequestURL().toString())
+      .uri(request.getRequestURI())
       .queryString(request.getQueryString() == null ? null : QUERY_PREFIX + request.getQueryString())
       .build();
   }

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,46 @@
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+    <!--콘솔 공통-->
+    <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <Pattern>${CONSOLE_LOG_PATTERN}</Pattern>
+            <charset>utf8</charset>
+        </encoder>
+    </appender>
+
+    <!--Local : 콘솔O 디스코드 알림X-->
+    <springProfile name="local">
+        <include resource="console-appender.xml"/>
+        <root level="INFO">
+            <appender-ref ref="Console"/>
+        </root>
+    </springProfile>
+
+    <!--BLUE & GREEN : 콘솔O 디스코드 알림O-->
+    <springProfile name="blue, green">
+        <property resource="application-secret.yml"/>
+        <springProperty name="DISCORD_WEBHOOK_URL" source="logging.discord.webhook-url"/>
+        <appender name="DISCORD" class="com.github.napstr.logback.DiscordAppender">
+            <webhookUri>${DISCORD_WEBHOOK_URL}</webhookUri>
+            <layout class="ch.qos.logback.classic.PatternLayout">
+                <pattern>### [Summary]%n%ex{0}### [Time]%n%d{yyyy-MM-dd HH:mm:ss}%n### [Level]%n%-5level%n### [Details]%n```%ex{full}```</pattern>
+            </layout>
+            <username> 🚨ERROR LOGS 🚨 </username>
+            <avatarUrl>https://agarang-s3-bucket.s3.ap-northeast-2.amazonaws.com/logs/logdog.png</avatarUrl>
+            <tts>false</tts>
+        </appender>
+
+        <appender name="ASYNC_DISCORD" class="ch.qos.logback.classic.AsyncAppender">
+            <appender-ref ref="DISCORD" />
+            <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+                <level>ERROR</level>
+            </filter>
+        </appender>
+
+        <root level="INFO">
+            <appender-ref ref="ASYNC_DISCORD"/>
+            <appender-ref ref="Console"/>
+        </root>
+    </springProfile>
+</configuration>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -24,7 +24,7 @@
         <appender name="DISCORD" class="com.github.napstr.logback.DiscordAppender">
             <webhookUri>${DISCORD_WEBHOOK_URL}</webhookUri>
             <layout class="ch.qos.logback.classic.PatternLayout">
-                <pattern>### [Summary]%n%ex{0}### [Time]%n%d{yyyy-MM-dd HH:mm:ss}%n### [Level]%n%-5level%n### [Details]%n```%ex{full}```</pattern>
+                <pattern>### [Summary]%n%ex{0}### [Time]%n%d{yyyy-MM-dd HH:mm:ss}%n### [Level]%n%-5level%n### [Header]%n- host: %mdc{host}%n- url: %mdc{method}  %mdc{url}%mdc{query}%n- cookie: %mdc{cookie}%n### [Details]%n```%ex{full}```</pattern>
             </layout>
             <username> 🚨ERROR LOGS 🚨 </username>
             <avatarUrl>https://agarang-s3-bucket.s3.ap-northeast-2.amazonaws.com/logs/logdog.png</avatarUrl>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -24,7 +24,7 @@
         <appender name="DISCORD" class="com.github.napstr.logback.DiscordAppender">
             <webhookUri>${DISCORD_WEBHOOK_URL}</webhookUri>
             <layout class="ch.qos.logback.classic.PatternLayout">
-                <pattern>### [Summary]%n%ex{0}### [Time]%n%d{yyyy-MM-dd HH:mm:ss}%n### [Level]%n%-5level%n### [Header]%n- host: %mdc{host}%n- url: %mdc{method}  %mdc{url}%mdc{query}%n- cookie: %mdc{cookie}%n### [Details]%n```%ex{full}```</pattern>
+                <pattern>### [Summary]%n%ex{0}### [Time]%n%d{yyyy-MM-dd HH:mm:ss}%n### [Level]%n%-5level%n### [Header]%n- host: %mdc{host}%n- uri: %mdc{method}  %mdc{uri}%mdc{query}%n- cookie: %mdc{cookie}%n### [Details]%n```%ex{full}```</pattern>
             </layout>
             <username> 🚨ERROR LOGS 🚨 </username>
             <avatarUrl>https://agarang-s3-bucket.s3.ap-northeast-2.amazonaws.com/logs/logdog.png</avatarUrl>


### PR DESCRIPTION

## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#38 

<br/>

## 📝작업 내용 (수정사항 반영)

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

서버에서 ERROR 레벨의 로그 발생 시 디스코드로 에러 로그과 요청 헤더의 정보를 담은 메시지가 전송됩니다.

**즉, 예외처리되지 않은 에러가 발생할 경우 디스코드에서 알림을 받을 수 있습니다.**

로그는 `logback` 라이브러리를 이용하여 기록하며, `logback-discord-appender` 라이브러리를 통해 디스코드와 연동됩니다.

 local 프로필 환경에서는 디스코드 알림이 작동하지 않습니다.

[노션 링크-자세한 구현방법 확인하기](https://goo99.notion.site/Infra-EC2-995e100e6eb54e56a7f527b53fc71cd4?pvs=4)

<br/>

### 스크린샷 (선택)

![스크린샷 2024-07-24 오전 3 31 43](https://github.com/user-attachments/assets/2986b239-5717-475d-aaa5-135c7d6d1a3f)

<br/>

## 💬리뷰 요구사항(선택) (수정사항 반영)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

로컬 테스트는 완료되었는데 서버 테스트는 머지 이후에 진행하려고 합니다!

디스코드 웹훅 url 은 application-secret 파일에 저장할 예정입니다. 머지 이후에 업데이트 해주세요.

추가적으로 알림 내용에 담겼으면 하는 내용이 있다면 말씀해주세요!

---

인터셉터에서 에러 발생 시 MDC 를 활용하여 로컬에 잠시 저장합니다.
이후 다음 번에 에러 발생할 경우 MDC 의 컨텐츠를 clear() 처리 후 업데이트 합니다.

혹시나 다른 서비스에서 MDC 활용 중에 에러가 발생하면 clear() 처리 때문에 기존 정보가 누락될 위험이 있습니다.
키값으로 각각 지우는 방법이 있으나 아직 MDC 를 다른 곳에서 활용할 가능성이 낮다고 판단해서 수정하지 않았습니다.

혹시 더 나은 방법이 있다면...알려주십쇼!!