### PR TITLE
[Feature] TTS 요청 시 webhook 으로 응답 받기

### DIFF
--- a/src/main/java/com/kuit/agarang/domain/ai/controller/TypecastController.java
+++ b/src/main/java/com/kuit/agarang/domain/ai/controller/TypecastController.java
@@ -1,0 +1,22 @@
+package com.kuit.agarang.domain.ai.controller;
+
+import com.kuit.agarang.domain.ai.model.dto.TypecastWebhookResponse;
+import com.kuit.agarang.domain.ai.service.TypecastService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/ai/tts")
+@RequiredArgsConstructor
+public class TypecastController {
+
+  private final TypecastService typecastService;
+
+  @PostMapping("/webhook")
+  public void webhook(@RequestBody TypecastWebhookResponse response) {
+    typecastService.saveAudio(response);
+  }
+}

--- a/src/main/java/com/kuit/agarang/domain/ai/model/dto/MessageRequest.java
+++ b/src/main/java/com/kuit/agarang/domain/ai/model/dto/MessageRequest.java
@@ -1,10 +1,13 @@
 package com.kuit.agarang.domain.ai.model.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
+@AllArgsConstructor
 @NoArgsConstructor
 public class MessageRequest {
+  // TODO : actor 정보 추가 (남아 or 여아)
   private String text;
 }

--- a/src/main/java/com/kuit/agarang/domain/ai/model/dto/TypecastWebhookResponse.java
+++ b/src/main/java/com/kuit/agarang/domain/ai/model/dto/TypecastWebhookResponse.java
@@ -1,0 +1,13 @@
+package com.kuit.agarang.domain.ai.model.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class TypecastWebhookResponse {
+  private String status;
+  @JsonProperty("audio_download_url")
+  private String audioDownloadUrl;
+}

--- a/src/main/java/com/kuit/agarang/domain/ai/model/entity/TypecastAudio.java
+++ b/src/main/java/com/kuit/agarang/domain/ai/model/entity/TypecastAudio.java
@@ -1,0 +1,25 @@
+package com.kuit.agarang.domain.ai.model.entity;
+
+import com.kuit.agarang.global.common.model.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TypecastAudio extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Lob
+  @Column(columnDefinition = "TEXT")
+  private String audioDownloadUrl;
+
+  public TypecastAudio(String audioDownloadUrl) {
+    this.audioDownloadUrl = audioDownloadUrl;
+  }
+}

--- a/src/main/java/com/kuit/agarang/domain/ai/model/repository/TypecastAudioRepository.java
+++ b/src/main/java/com/kuit/agarang/domain/ai/model/repository/TypecastAudioRepository.java
@@ -1,0 +1,7 @@
+package com.kuit.agarang.domain.ai.model.repository;
+
+import com.kuit.agarang.domain.ai.model.entity.TypecastAudio;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TypecastAudioRepository extends JpaRepository<TypecastAudio, Long> {
+}

--- a/src/main/java/com/kuit/agarang/domain/ai/service/TypecastService.java
+++ b/src/main/java/com/kuit/agarang/domain/ai/service/TypecastService.java
@@ -1,9 +1,11 @@
 package com.kuit.agarang.domain.ai.service;
 
 import com.kuit.agarang.domain.ai.model.dto.MessageRequest;
-import com.kuit.agarang.domain.ai.model.dto.TypecastAudioResponse;
 import com.kuit.agarang.domain.ai.model.dto.TypecastRequest;
 import com.kuit.agarang.domain.ai.model.dto.TypecastResponse;
+import com.kuit.agarang.domain.ai.model.dto.TypecastWebhookResponse;
+import com.kuit.agarang.domain.ai.model.entity.TypecastAudio;
+import com.kuit.agarang.domain.ai.model.repository.TypecastAudioRepository;
 import com.kuit.agarang.domain.ai.utils.TypecastClientUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -16,15 +18,17 @@ public class TypecastService {
   @Value("${typecast.actorId}")
   private String actorId;
   private final TypecastClientUtil typeCastClientUtil;
+  private final TypecastAudioRepository typecastAudioRepository;
 
-  public String getAudioDownloadUrl(MessageRequest request) throws InterruptedException {
-    TypecastResponse typecastResponse =
-      typeCastClientUtil.post("/api/speak", TypecastRequest.create(request, actorId), TypecastResponse.class);
+  public void getAudioDownloadUrl(MessageRequest request) {
+    typeCastClientUtil.post("/api/speak", TypecastRequest.create(request, actorId), TypecastResponse.class);
+  }
 
-    Thread.sleep(1500); // TODO : Tread 삭제 후 call-back url 로 구현하기
-
-    TypecastAudioResponse typecastAudioResponse =
-      typeCastClientUtil.get(typecastResponse.getResult().getSpeakV2Url(), TypecastAudioResponse.class);
-    return typecastAudioResponse.getResult().getAudioDownloadUrl();
+  public void saveAudio(TypecastWebhookResponse response) {
+    if ("failed".equals(response.getStatus())) {
+      // TODO : 예외처리 (done or failed)
+    }
+    // TODO : redis cache 저장으로 변경 (일회성 데이터)
+    typecastAudioRepository.save(new TypecastAudio(response.getAudioDownloadUrl()));
   }
 }

--- a/src/main/java/com/kuit/agarang/domain/ai/utils/TypecastClientUtil.java
+++ b/src/main/java/com/kuit/agarang/domain/ai/utils/TypecastClientUtil.java
@@ -15,7 +15,7 @@ public class TypecastClientUtil {
   @Value("${typecast.apiKey}")
   private String apiKey;
 
-  public <T> T post(String uri, TypecastRequest requestDto, Class<T> responseClass) {
+  public <T, V> T post(String uri, V requestDto, Class<T> responseClass) {
     return webClientUtil.post(baseUrl + uri, apiKey, requestDto, responseClass);
   }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#46 

<br/>

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

tts 로 오디오 파일을 생성할 때 webhook 으로 빠른 응답을 받습니다. (docs 권장 사항)

자세한 구현사항은 노션을 참고해주세요.

[노션 정리](https://goo99.notion.site/AI-TTS-Webhook-bab3d6da6dad470bbd23bca63f51a7e6?pvs=4)

<br/>

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

gpt 와 관련된 주요 로직은 동기적으로 이루어져야 합니다.

```
이미지 등록 -> s3 이미지 저장(이건 비동기일 수도) -> 이미지를 통해 gpt 질문 생성 -> 질문 tts -> 질문 텍스트과 오디오 파일 return
```

이때 tts 에 걸리는 시간을 계산했을 때 다음과 같습니다..
- 요청 ~ 응답 ~ DB 저장 : 1.93초
- 요청 ~ 응답 : 1.376 초

만약 레디스를 사용하게 되면 1.5초 쯤 걸릴 것 같은데 생각보다 오래걸리는 것 같아서, webhook 을 기다리는 로직이 필요합니다.

고민해봤을 때 떠오르는 생각은
웹훅 요청이 캐시에 저장됐는지 확인하면서(1.5초간격 2번 정도...??) 기다리다가 캐시에 저장된 것을 확인하자마자 응답하는 방식인데..
혹시 더 좋은 아이디어가 있다면 공유해요!!