### PR TITLE
[Hotfix] redis-repository 및 jpa 빌드 설정

### DIFF
--- a/src/main/java/com/kuit/agarang/global/common/config/RedisConfig.java
+++ b/src/main/java/com/kuit/agarang/global/common/config/RedisConfig.java
@@ -6,12 +6,10 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
-@EnableRedisRepositories
 public class RedisConfig {
 
   @Value("${spring.data.redis.host}")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,6 +24,14 @@ spring:
       max-file-size: 5MB
       max-request-size: 10MB
 
+  data:
+    redis:
+      repositories:
+        enabled: false
+    jpa:
+      repositories:
+        bootstrap-mode: deferred
+
 aws:
   s3:
     upload:


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### spring.data.redis.repositories.enabled: false

현 프로젝트에서는 리포지토리를 사용한 redis 가 아니므로 Redis 리포지토리를 비활성화합니다. (빌드 시간 단축)

### spring.jpa.repositories.bootstrap-mode: deferred

JPA 리포지토리의 초기화 모드를 deferred 으로 설정합니다.
-> 애플리케이션 컨텍스트가 완전히 초기화된 후에 JPA 리포지토리가 초기화됩니다. (빌드 오류 확인용)