### PR TITLE
[Hotfix] memory 삭제 시 hashtag 삭제 누락

### DIFF
--- a/src/main/java/com/kuit/agarang/domain/memory/repository/HashTagRepository.java
+++ b/src/main/java/com/kuit/agarang/domain/memory/repository/HashTagRepository.java
@@ -1,0 +1,9 @@
+package com.kuit.agarang.domain.memory.repository;
+
+import com.kuit.agarang.domain.memory.model.entity.Hashtag;
+import com.kuit.agarang.domain.memory.model.entity.Memory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface HashTagRepository extends JpaRepository<Hashtag, Long> {
+  void deleteByMemory(Memory memory);
+}

--- a/src/main/java/com/kuit/agarang/domain/memory/service/MemoryService.java
+++ b/src/main/java/com/kuit/agarang/domain/memory/service/MemoryService.java
@@ -2,25 +2,14 @@ package com.kuit.agarang.domain.memory.service;
 
 import com.kuit.agarang.domain.baby.model.entity.Baby;
 import com.kuit.agarang.domain.member.model.entity.Member;
-import com.kuit.agarang.domain.memory.model.dto.BookmarkRequest;
-import com.kuit.agarang.domain.memory.model.dto.DeleteMemoryRequest;
-import com.kuit.agarang.domain.memory.model.dto.ModifyMemoryRequest;
-import com.kuit.agarang.domain.memory.model.dto.DailyMemoryDTO;
-import com.kuit.agarang.domain.memory.model.dto.FavoriteMemoriesResponse;
-import com.kuit.agarang.domain.memory.model.dto.DailyMemoryResponse;
-import com.kuit.agarang.domain.memory.model.dto.DailyMemoriesResponse;
-import com.kuit.agarang.domain.memory.model.dto.MemoryBookmarkedDTO;
-import com.kuit.agarang.domain.memory.model.dto.MemoryDTO;
-import com.kuit.agarang.domain.memory.model.dto.MemoryImageDTO;
-import com.kuit.agarang.domain.memory.model.dto.MemoryRequest;
-import com.kuit.agarang.domain.memory.model.dto.MonthlyMemoryDTO;
-import com.kuit.agarang.domain.memory.model.dto.MonthlyMemoryResponse;
+import com.kuit.agarang.domain.memory.model.dto.*;
 import com.kuit.agarang.domain.memory.model.entity.Memory;
 import com.kuit.agarang.domain.memory.model.entity.MemoryBookmark;
+import com.kuit.agarang.domain.memory.repository.HashTagRepository;
 import com.kuit.agarang.domain.memory.repository.MemoryBookmarkRepository;
 import com.kuit.agarang.domain.memory.repository.MemoryRepository;
-import com.kuit.agarang.domain.playlist.repository.MemoryPlaylistRepository;
 import com.kuit.agarang.domain.memory.repository.MusicBookmarkRepository;
+import com.kuit.agarang.domain.playlist.repository.MemoryPlaylistRepository;
 import com.kuit.agarang.global.common.exception.exception.BusinessException;
 import com.kuit.agarang.global.common.model.dto.BaseResponseStatus;
 import com.kuit.agarang.global.common.utils.DateUtil;
@@ -31,11 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -47,6 +32,7 @@ public class MemoryService {
   private final MemoryBookmarkRepository memoryBookmarkRepository;
   private final MusicBookmarkRepository musicBookmarkRepository;
   private final MemoryPlaylistRepository memoryPlaylistRepository;
+  private final HashTagRepository hashTagRepository;
 
   public DailyMemoryResponse findMemory(MemoryRequest memoryRequest) {
     String date = memoryRequest.getDate();
@@ -153,6 +139,7 @@ public class MemoryService {
     memoryBookmarkRepository.deleteByMemory(memory);
     musicBookmarkRepository.deleteByMemory(memory);
     memoryPlaylistRepository.deleteByMemory(memory);
+    hashTagRepository.deleteByMemory(memory);
     memoryRepository.delete(memory);
   }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #82 

<br/>

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

```
Cannot delete or update a parent row:
    a foreign key constraint fails (`agarang`.`hashtag`, CONSTRAINT `FKbhsnr9f7vjk4p6dancp3daem1` FOREIGN KEY (`memory_id`) REFERENCES `memory` (`id`))
```

`hashtag` 테이블은 `memory` 테이블의 `foreign key(memory_id)` 를 참조하고 있습니다.

이 상황에서 `hashtag` 를 먼저 정리하지 않고 `memory` 레코드를 삭제하려고 하면,
`hashtag` 테이블에 남아 있는 `memory_id` 가 유효하지 않은 `memory` 레코드를 가리키게 됩니다.

이로 인해 외래 키 제약 조건 위반 오류가 발생하게 되어 위와같은 오류가 발생한 것입니다.

[노션 링크](https://goo99.notion.site/JPA-761fbe555937403cac9df652fc8e43e0?pvs=4)

<br/>

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

이 부분 현재 프엔에서 연동 진행중이므로 우선 머지하겠습니다.