### PR TITLE
[Feature] Refresh token, ReissueController 구현 

### DIFF
--- a/src/main/java/com/kuit/agarang/domain/login/controller/ReissueController.java
+++ b/src/main/java/com/kuit/agarang/domain/login/controller/ReissueController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import static com.kuit.agarang.global.common.model.dto.BaseResponseStatus.NOT_FOUND_MEMBER;
+import static com.kuit.agarang.global.common.model.dto.BaseResponseStatus.SUCCESS;
 
 @Slf4j
 @RestController
@@ -26,21 +27,16 @@ public class ReissueController {
 
   private final JWTService jwtService;
   private final CookieUtil cookieUtil;
-  private final MemberRepository memberRepository;
 
   @PostMapping("/reissue")
   public ResponseEntity<BaseResponse<ReissueDto>> reissue(@AuthenticationPrincipal CustomOAuth2User details,
                                                           HttpServletRequest request, HttpServletResponse response) {
 
-    Long memberId = details.getMemberId();
-    Member member = memberRepository.findById(memberId).orElseThrow(() -> new BusinessException(NOT_FOUND_MEMBER));
+    ReissueDto reissueDto = jwtService.reissueTokens(details.getMemberId());
 
-    String refresh = member.getRefreshToken().getValue();
-    ReissueDto reissueDto = jwtService.reissueTokens(refresh); // newAccess, newRefresh 토큰 생성
     response.addCookie(cookieUtil.createCookie("Authorization", reissueDto.getNewAccessToken()));
-
     log.info("New Access Token = {}", reissueDto.getNewAccessToken());
 
-    return ResponseEntity.ok(new BaseResponse<>());
+    return ResponseEntity.ok(new BaseResponse<>(SUCCESS));
   }
 }

--- a/src/main/java/com/kuit/agarang/domain/login/controller/ReissueController.java
+++ b/src/main/java/com/kuit/agarang/domain/login/controller/ReissueController.java
@@ -40,7 +40,6 @@ public class ReissueController {
     response.addCookie(cookieUtil.createCookie("Authorization", reissueDto.getNewAccessToken()));
 
     log.info("New Access Token = {}", reissueDto.getNewAccessToken());
-    log.info("New Refresh Token = {}", reissueDto.getNewRefreshToken());
 
     return ResponseEntity.ok(new BaseResponse<>());
   }

--- a/src/main/java/com/kuit/agarang/domain/login/controller/ReissueController.java
+++ b/src/main/java/com/kuit/agarang/domain/login/controller/ReissueController.java
@@ -30,14 +30,13 @@ public class ReissueController {
 
   @PostMapping("/reissue")
   public ResponseEntity<BaseResponse<ReissueDto>> reissue(@AuthenticationPrincipal CustomOAuth2User details,
-                                                          HttpServletResponse response) {
+                                                          HttpServletRequest request, HttpServletResponse response) {
 
     Long memberId = details.getMemberId();
     Member member = memberRepository.findById(memberId).orElseThrow(() -> new BusinessException(NOT_FOUND_MEMBER));
 
     String refresh = member.getRefreshToken().getValue();
-
-    ReissueDto reissueDto = jwtService.reissueTokens(refresh);
+    ReissueDto reissueDto = jwtService.reissueTokens(refresh); // newAccess, newRefresh 토큰 생성
     response.addCookie(cookieUtil.createCookie("Authorization", reissueDto.getNewAccessToken()));
 
     log.info("New Access Token = {}", reissueDto.getNewAccessToken());

--- a/src/main/java/com/kuit/agarang/domain/login/controller/ReissueController.java
+++ b/src/main/java/com/kuit/agarang/domain/login/controller/ReissueController.java
@@ -1,42 +1,48 @@
 package com.kuit.agarang.domain.login.controller;
 
+import com.kuit.agarang.domain.login.model.dto.CustomOAuth2User;
 import com.kuit.agarang.domain.login.model.dto.ReissueDto;
 import com.kuit.agarang.domain.login.service.JWTService;
 import com.kuit.agarang.domain.login.utils.CookieUtil;
+import com.kuit.agarang.domain.member.model.entity.Member;
+import com.kuit.agarang.domain.member.repository.MemberRepository;
+import com.kuit.agarang.global.common.exception.exception.BusinessException;
 import com.kuit.agarang.global.common.model.dto.BaseResponse;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.io.UnsupportedEncodingException;
+import static com.kuit.agarang.global.common.model.dto.BaseResponseStatus.NOT_FOUND_MEMBER;
 
-import static com.kuit.agarang.global.common.model.dto.BaseResponseStatus.*;
-
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 public class ReissueController {
 
   private final JWTService jwtService;
   private final CookieUtil cookieUtil;
+  private final MemberRepository memberRepository;
 
   @PostMapping("/reissue")
-  public ResponseEntity<BaseResponse<ReissueDto>> reissue(HttpServletRequest request, HttpServletResponse response) throws UnsupportedEncodingException {
+  public ResponseEntity<BaseResponse<ReissueDto>> reissue(@AuthenticationPrincipal CustomOAuth2User details,
+                                                          HttpServletResponse response) {
 
-    String refresh = null;
-    Cookie[] cookies = request.getCookies();
-    for (Cookie cookie : cookies) {
-      if (cookie.getName().equals("refresh")) {
-        refresh = cookie.getValue();
-      }
-    }
+    Long memberId = details.getMemberId();
+    Member member = memberRepository.findById(memberId).orElseThrow(() -> new BusinessException(NOT_FOUND_MEMBER));
+
+    String refresh = member.getRefreshToken().getValue();
 
     ReissueDto reissueDto = jwtService.reissueTokens(refresh);
-    response.setHeader("Authorization", reissueDto.getNewAccessToken());
-    response.addCookie(cookieUtil.createCookie("refresh", reissueDto.getNewRefreshToken()));
-    return new ResponseEntity<>(new BaseResponse<>(reissueDto), SUCCESS.getHttpStatus());
+    response.addCookie(cookieUtil.createCookie("Authorization", reissueDto.getNewAccessToken()));
+
+    log.info("New Access Token = {}", reissueDto.getNewAccessToken());
+    log.info("New Refresh Token = {}", reissueDto.getNewRefreshToken());
+
+    return ResponseEntity.ok(new BaseResponse<>());
   }
 }

--- a/src/main/java/com/kuit/agarang/domain/login/filter/JWTFilter.java
+++ b/src/main/java/com/kuit/agarang/domain/login/filter/JWTFilter.java
@@ -54,7 +54,6 @@ public class JWTFilter extends OncePerRequestFilter {
       return;
     }
 
-    // providerId, role 값을 획득
     String providerId = jwtUtil.getProviderId(accessToken);
     String role = jwtUtil.getRole(accessToken);
     Long memberId = jwtUtil.getMemberId(accessToken);

--- a/src/main/java/com/kuit/agarang/domain/login/handler/CustomSuccessHandler.java
+++ b/src/main/java/com/kuit/agarang/domain/login/handler/CustomSuccessHandler.java
@@ -1,6 +1,5 @@
 package com.kuit.agarang.domain.login.handler;
 
-import com.kuit.agarang.domain.login.service.JWTService;
 import com.kuit.agarang.domain.login.utils.AuthenticationUtil;
 import com.kuit.agarang.domain.login.utils.CookieUtil;
 import com.kuit.agarang.domain.login.utils.JWTUtil;
@@ -46,7 +45,7 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     // 토큰 생성
     String access = jwtUtil.createAccessToken(providerId, role, memberId);
     String refresh = jwtUtil.createRefreshToken(providerId, role, memberId);
-    log.info("onAuthenticationSuccess accessToken = {}", access);
+    log.info("AccessToken = {}", access);
 
     // Refresh 토큰 저장
     RefreshToken refreshToken = RefreshToken.of(refresh);

--- a/src/main/java/com/kuit/agarang/domain/login/handler/CustomSuccessHandler.java
+++ b/src/main/java/com/kuit/agarang/domain/login/handler/CustomSuccessHandler.java
@@ -4,20 +4,24 @@ import com.kuit.agarang.domain.login.service.JWTService;
 import com.kuit.agarang.domain.login.utils.AuthenticationUtil;
 import com.kuit.agarang.domain.login.utils.CookieUtil;
 import com.kuit.agarang.domain.login.utils.JWTUtil;
+import com.kuit.agarang.domain.member.model.entity.Member;
+import com.kuit.agarang.domain.member.model.entity.RefreshToken;
 import com.kuit.agarang.domain.member.repository.MemberRepository;
-import com.kuit.agarang.global.common.model.dto.BaseResponse;
-import com.kuit.agarang.global.common.model.dto.BaseResponseStatus;
+import com.kuit.agarang.domain.member.repository.RefreshRepository;
+import com.kuit.agarang.global.common.exception.exception.BusinessException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
+
+import static com.kuit.agarang.global.common.model.dto.BaseResponseStatus.NOT_FOUND_MEMBER;
 
 @Slf4j
 @Component
@@ -27,34 +31,34 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
   private final AuthenticationUtil authenticationUtil;
   private final JWTUtil jwtUtil;
   private final CookieUtil cookieUtil;
-  private final JWTService jwtService;
   private final MemberRepository memberRepository;
-//  @Value("${app.baseUrl}")
-//  private String baseUrl;
+  private final RefreshRepository refreshRepository;
 
   @Override
+  @Transactional
   public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
 
-    // 유저 정보
     String providerId = authenticationUtil.getProviderId();
     String role = authenticationUtil.getRole();
-    Long memberId = memberRepository.findByProviderId(providerId).get().getId();
-    log.info("providerId = {}", providerId);
-    log.info("role = {}", role);
-    log.info("memberId = {}", memberId);
+    Long memberId = memberRepository.findByProviderId(providerId)
+        .orElseThrow(() -> new BusinessException(NOT_FOUND_MEMBER)).getId();
 
     // 토큰 생성
     String access = jwtUtil.createAccessToken(providerId, role, memberId);
     String refresh = jwtUtil.createRefreshToken(providerId, role, memberId);
-    log.info("access = {}", access);
-    log.info("refresh = {}", refresh);
+    log.info("onAuthenticationSuccess accessToken = {}", access);
 
     // Refresh 토큰 저장
-    jwtService.addRefreshEntity(providerId, refresh);
+    RefreshToken refreshToken = RefreshToken.of(refresh);
+    refreshRepository.save(refreshToken);
+
+    Member member = memberRepository.findById(memberId)
+        .orElseThrow(() -> new BusinessException(NOT_FOUND_MEMBER));
+    member.addRefreshToken(refreshToken);
+    memberRepository.save(member);
 
     // 응답 설정
     response.addCookie(cookieUtil.createCookie("Authorization", access));
-    response.addCookie(cookieUtil.createCookie("refresh", refresh));
     response.setStatus(HttpStatus.OK.value());
   }
 }

--- a/src/main/java/com/kuit/agarang/domain/login/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/kuit/agarang/domain/login/service/CustomOAuth2UserService.java
@@ -27,7 +27,8 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     OAuth2User oAuth2User = super.loadUser(userRequest);
 
     String registrationId = userRequest.getClientRegistration().getRegistrationId();
-    OAuth2Response oAuth2Response = null;
+    OAuth2Response oAuth2Response;
+    log.info("oAuth2User.getAttributes() = {}", oAuth2User.getAttributes());
     switch (registrationId) {
       case "naver" -> oAuth2Response = new NaverResponse(oAuth2User.getAttributes());
       case "kakao" -> oAuth2Response = new KakaoResponse(oAuth2User.getAttributes());

--- a/src/main/java/com/kuit/agarang/domain/login/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/kuit/agarang/domain/login/service/CustomOAuth2UserService.java
@@ -28,7 +28,6 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
     String registrationId = userRequest.getClientRegistration().getRegistrationId();
     OAuth2Response oAuth2Response = null;
-
     switch (registrationId) {
       case "naver" -> oAuth2Response = new NaverResponse(oAuth2User.getAttributes());
       case "kakao" -> oAuth2Response = new KakaoResponse(oAuth2User.getAttributes());

--- a/src/main/java/com/kuit/agarang/domain/login/service/JWTService.java
+++ b/src/main/java/com/kuit/agarang/domain/login/service/JWTService.java
@@ -61,7 +61,6 @@ public class JWTService {
     try {
       jwtUtil.isExpired(refresh);
     } catch (ExpiredJwtException e) {
-      refreshRepository.deleteByValue(refresh);
       throw new BusinessException(NOT_FOUND_REFRESH_TOKEN);
     }
 

--- a/src/main/java/com/kuit/agarang/domain/login/service/JWTService.java
+++ b/src/main/java/com/kuit/agarang/domain/login/service/JWTService.java
@@ -12,8 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import static com.kuit.agarang.global.common.model.dto.BaseResponseStatus.NOT_FOUND_MEMBER;
-import static com.kuit.agarang.global.common.model.dto.BaseResponseStatus.NOT_FOUND_REFRESH_TOKEN;
+import static com.kuit.agarang.global.common.model.dto.BaseResponseStatus.*;
 
 @Service
 @RequiredArgsConstructor
@@ -57,7 +56,7 @@ public class JWTService {
     try {
       jwtUtil.isExpired(refresh);
     } catch (ExpiredJwtException e) {
-      throw new BusinessException(NOT_FOUND_REFRESH_TOKEN);
+      throw new BusinessException(EXPIRED_REFRESH_TOKEN);
     }
 
     String category = jwtUtil.getCategory(refresh);

--- a/src/main/java/com/kuit/agarang/domain/login/service/JWTService.java
+++ b/src/main/java/com/kuit/agarang/domain/login/service/JWTService.java
@@ -2,7 +2,9 @@ package com.kuit.agarang.domain.login.service;
 
 import com.kuit.agarang.domain.login.model.dto.ReissueDto;
 import com.kuit.agarang.domain.login.utils.JWTUtil;
+import com.kuit.agarang.domain.member.model.entity.Member;
 import com.kuit.agarang.domain.member.model.entity.RefreshToken;
+import com.kuit.agarang.domain.member.repository.MemberRepository;
 import com.kuit.agarang.domain.member.repository.RefreshRepository;
 import com.kuit.agarang.global.common.exception.exception.BusinessException;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -13,7 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Date;
 
-import static com.kuit.agarang.global.common.model.dto.BaseResponseStatus.BAD_REQUEST;
+import static com.kuit.agarang.global.common.model.dto.BaseResponseStatus.*;
 
 @Service
 @RequiredArgsConstructor
@@ -21,12 +23,9 @@ import static com.kuit.agarang.global.common.model.dto.BaseResponseStatus.BAD_RE
 public class JWTService {
 
   private final JWTUtil jwtUtil;
+  private final MemberRepository memberRepository;
   private final RefreshRepository refreshRepository;
 
-  @Value("${secret.jwt-refresh-expired-in}")
-  private Long REFRESH_EXPIRED_IN;
-
-  // TODO : Exception 추가
   public ReissueDto reissueTokens(String refresh) {
 
     validateRefreshToken(refresh);
@@ -39,9 +38,11 @@ public class JWTService {
     String newAccess = jwtUtil.createAccessToken(providerId, role, memberId);
     String newRefresh = jwtUtil.createRefreshToken(providerId, role, memberId);
 
-    // 기존 토큰 삭제 후 새로운 Refresh Token 저장
-    refreshRepository.deleteByValue(refresh);
-    addRefreshEntity(providerId, newRefresh);
+    // Refresh Token Update
+    Member member = memberRepository.findById(memberId).orElseThrow(() -> new BusinessException(NOT_FOUND_MEMBER));
+    RefreshToken refreshToken = refreshRepository.findById(member.getRefreshToken().getId())
+        .orElseThrow(() -> new BusinessException(NOT_FOUND_REFRESH_TOKEN));
+    refreshToken.changeValue(newRefresh);
 
     return ReissueDto.builder()
         .newAccessToken(newAccess)
@@ -51,40 +52,27 @@ public class JWTService {
         .build();
   }
 
-  public void addRefreshEntity(String providerId, String value) {
-    Date date = new Date(System.currentTimeMillis() + REFRESH_EXPIRED_IN);
-
-    RefreshToken refreshToken = RefreshToken.builder()
-        .providerId(providerId)
-        .value(value)
-        .expiration(date.toString()).build();
-
-    refreshRepository.save(refreshToken);
-  }
-
   private void validateRefreshToken(String refresh) {
 
     if (refresh == null) {
-      throw new BusinessException(BAD_REQUEST);
+      throw new BusinessException(NOT_FOUND_REFRESH_TOKEN);
     }
 
-    // 만료 여부 체크
     try {
       jwtUtil.isExpired(refresh);
     } catch (ExpiredJwtException e) {
-      throw new BusinessException(BAD_REQUEST);
+      refreshRepository.deleteByValue(refresh);
+      throw new BusinessException(NOT_FOUND_REFRESH_TOKEN);
     }
 
-    // 토큰이 refresh인지 확인 (발급시 페이로드에 명시)
     String category = jwtUtil.getCategory(refresh);
     if (!category.equals("refresh")) {
-      throw new BusinessException(BAD_REQUEST);
+      throw new BusinessException(NOT_FOUND_REFRESH_TOKEN);
     }
 
-    // DB에 저장되어 있는지 확인
     Boolean isExist = refreshRepository.existsByValue(refresh);
     if (!isExist) {
-      throw new BusinessException(BAD_REQUEST);
+      throw new BusinessException(NOT_FOUND_REFRESH_TOKEN);
     }
   }
 }

--- a/src/main/java/com/kuit/agarang/domain/login/utils/CookieUtil.java
+++ b/src/main/java/com/kuit/agarang/domain/login/utils/CookieUtil.java
@@ -1,6 +1,8 @@
 package com.kuit.agarang.domain.login.utils;
 
 import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.stereotype.Component;
 
 import java.io.UnsupportedEncodingException;

--- a/src/main/java/com/kuit/agarang/domain/member/model/entity/Member.java
+++ b/src/main/java/com/kuit/agarang/domain/member/model/entity/Member.java
@@ -53,7 +53,7 @@ public class Member extends BaseEntity {
     this.name = name;
     this.email = email;
   }
-
+  
   public static Member of(String providerId, String name, String email, String role) {
     return Member.builder()
         .providerId(providerId)

--- a/src/main/java/com/kuit/agarang/domain/member/model/entity/Member.java
+++ b/src/main/java/com/kuit/agarang/domain/member/model/entity/Member.java
@@ -21,7 +21,7 @@ public class Member extends BaseEntity {
   @JoinColumn(name = "baby_id")
   private Baby baby;
 
-  @OneToOne(fetch = FetchType.LAZY)
+  @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
   @JoinColumn(name = "refresh_token_id")
   private RefreshToken refreshToken;
 
@@ -66,6 +66,10 @@ public class Member extends BaseEntity {
   public void addBaby(Baby baby) {
     this.baby = baby;
     baby.getMembers().add(this);
+  }
+
+  public void addRefreshToken(RefreshToken refreshToken) {
+    this.refreshToken = refreshToken;
   }
 
   public void setFamilyRole(String familyRole) {

--- a/src/main/java/com/kuit/agarang/domain/member/model/entity/RefreshToken.java
+++ b/src/main/java/com/kuit/agarang/domain/member/model/entity/RefreshToken.java
@@ -13,6 +13,7 @@ public class RefreshToken extends BaseEntity {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
+  @Setter
   private String value;
 
   @Builder
@@ -24,9 +25,5 @@ public class RefreshToken extends BaseEntity {
     return RefreshToken.builder()
         .value(value)
         .build();
-  }
-
-  public void changeValue(String value) {
-    this.value = value;
   }
 }

--- a/src/main/java/com/kuit/agarang/domain/member/model/entity/RefreshToken.java
+++ b/src/main/java/com/kuit/agarang/domain/member/model/entity/RefreshToken.java
@@ -1,10 +1,7 @@
 package com.kuit.agarang.domain.member.model.entity;
 
 import com.kuit.agarang.global.common.model.entity.BaseEntity;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.*;
 
 @Entity
@@ -16,22 +13,20 @@ public class RefreshToken extends BaseEntity {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  private String providerId;
   private String value;
-  private String expiration;
 
   @Builder
-  public RefreshToken(String providerId, String value, String expiration) {
-    this.providerId = providerId;
+  public RefreshToken(String value) {
     this.value = value;
-    this.expiration = expiration;
   }
 
-  public static RefreshToken of(String providerId, String value, String expiration) {
+  public static RefreshToken of(String value) {
     return RefreshToken.builder()
-        .providerId(providerId)
         .value(value)
-        .expiration(expiration)
         .build();
+  }
+
+  public void changeValue(String value) {
+    this.value = value;
   }
 }

--- a/src/main/java/com/kuit/agarang/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/kuit/agarang/domain/member/repository/MemberRepository.java
@@ -1,7 +1,9 @@
 package com.kuit.agarang.domain.member.repository;
 
 import com.kuit.agarang.domain.member.model.entity.Member;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
@@ -9,4 +11,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
   Optional<Member> findByProviderId(String providerId);
 
+  @Query("SELECT m FROM Member m JOIN FETCH m.refreshToken WHERE m.id = :memberId")
+  Optional<Member> findByIdWithRefreshToken(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/kuit/agarang/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/kuit/agarang/domain/member/repository/MemberRepository.java
@@ -8,4 +8,5 @@ import java.util.Optional;
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
   Optional<Member> findByProviderId(String providerId);
+
 }

--- a/src/main/java/com/kuit/agarang/domain/member/repository/RefreshRepository.java
+++ b/src/main/java/com/kuit/agarang/domain/member/repository/RefreshRepository.java
@@ -7,6 +7,4 @@ import org.springframework.transaction.annotation.Transactional;
 public interface RefreshRepository extends JpaRepository<RefreshToken, Long> {
 
   Boolean existsByValue(String value);
-
-  void deleteByValue(String value);
 }

--- a/src/main/java/com/kuit/agarang/domain/member/repository/RefreshRepository.java
+++ b/src/main/java/com/kuit/agarang/domain/member/repository/RefreshRepository.java
@@ -7,5 +7,6 @@ import org.springframework.transaction.annotation.Transactional;
 public interface RefreshRepository extends JpaRepository<RefreshToken, Long> {
 
   Boolean existsByValue(String value);
+
   void deleteByValue(String value);
 }

--- a/src/main/java/com/kuit/agarang/global/common/model/dto/BaseResponseStatus.java
+++ b/src/main/java/com/kuit/agarang/global/common/model/dto/BaseResponseStatus.java
@@ -20,6 +20,7 @@ public enum BaseResponseStatus {
   NOT_FOUND_CHARACTER(false, HttpStatus.NOT_FOUND, 4022, "캐릭터를 찾을 수 없습니다"),
   NOT_FOUND_MEMBER(false, HttpStatus.NOT_FOUND, 4023, "사용자를 찾을 수 없습니다"),
   NOT_FOUND_REFRESH_TOKEN(false, HttpStatus.NOT_FOUND, 4024, "리프레시 토큰을 찾을 수 없습니다"),
+  EXPIRED_REFRESH_TOKEN(false, HttpStatus.NOT_FOUND, 4025, "리프레시 토큰이 만료되었습니다."),
 
   INVALID_FILE_EXTENSION(false, HttpStatus.BAD_REQUEST, 4003, "지원하지 않는 파일확장자입니다."),
   NOT_FOUND_RESOURCE(false, HttpStatus.NOT_FOUND, 4004, "존재하지 않는 페이지입니다."),

--- a/src/main/java/com/kuit/agarang/global/common/model/dto/BaseResponseStatus.java
+++ b/src/main/java/com/kuit/agarang/global/common/model/dto/BaseResponseStatus.java
@@ -16,9 +16,10 @@ public enum BaseResponseStatus {
   INVALID_MEMORY_ID(false, HttpStatus.NOT_FOUND, 4001, "존재하지 않는 추억입니다."),
   FILE_TOO_LARGE(false, HttpStatus.PAYLOAD_TOO_LARGE, 4002, "최대 파일 사이즈(1MB)를 초과했습니다."),
 
-  NOT_FOUND_BABY(false, HttpStatus.NOT_FOUND, 4009, "아기를 찾을 수 없습니다"),
-  NOT_FOUND_CHARACTER(false, HttpStatus.NOT_FOUND, 4010, "캐릭터를 찾을 수 없습니다"),
-  NOT_FOUND_MEMBER(false, HttpStatus.NOT_FOUND, 4011, "사용자를 찾을 수 없습니다"),
+  NOT_FOUND_BABY(false, HttpStatus.NOT_FOUND, 4021, "아기를 찾을 수 없습니다"),
+  NOT_FOUND_CHARACTER(false, HttpStatus.NOT_FOUND, 4022, "캐릭터를 찾을 수 없습니다"),
+  NOT_FOUND_MEMBER(false, HttpStatus.NOT_FOUND, 4023, "사용자를 찾을 수 없습니다"),
+  NOT_FOUND_REFRESH_TOKEN(false, HttpStatus.NOT_FOUND, 4024, "리프레시 토큰을 찾을 수 없습니다"),
 
   INVALID_FILE_EXTENSION(false, HttpStatus.BAD_REQUEST, 4003, "지원하지 않는 파일확장자입니다."),
   NOT_FOUND_RESOURCE(false, HttpStatus.NOT_FOUND, 4004, "존재하지 않는 페이지입니다."),

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,12 +11,12 @@ spring:
   jpa:
     generate-ddl: true
     hibernate:
-      ddl-auto: create
-#    properties:
-#      hibernate:
-#        show_sql: true
-#        format_sql: true
-#    open-in-view: true
+      ddl-auto: update
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+    open-in-view: true
 
   data:
     redis:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,12 +11,12 @@ spring:
   jpa:
     generate-ddl: true
     hibernate:
-      ddl-auto: update
-    properties:
-      hibernate:
-        show_sql: true
-        format_sql: true
-    open-in-view: true
+      ddl-auto: create
+#    properties:
+#      hibernate:
+#        show_sql: true
+#        format_sql: true
+#    open-in-view: true
 
   data:
     redis:


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #78 


<br/>

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

1. 소셜 로그인 및 회원가입:
- 소셜 로그인 후, AccessToken과 RefreshToken을 생성합니다.
- AccessToken은 쿠키 방식으로 클라이언트에 전달하고, RefreshToken은 데이터베이스에 저장합니다.
- Member와 RefreshToken은 일대일 관계로, 각 Member는 항상 하나의 RefreshToken을 가집니다.
- Refresh Rotation 방식으로 AccessToken 재발급 시 Refresh도 함께 재발급합니다.

2. RefreshEntity 수정:
- providerId와 expiration 필드를 제거했습니다.
- 서버에서 복호화하여 필요한 값을 가져올 수 있고, 딱히 쓰는곳도 없어서 지웠는데, 추후 필요하면 다시 넣겠습니다.

3. MemberEntity 수정:
- RefreshToken 필드에 Cascade 설정을 추가했습니다.
- RefreshToken은 삭제 후 재추가하지 않고, 값만 업데이트하는 방식으로 변경했습니당. 
- 해당 과정을 공부하던 중 정말 좋은 링크 찾아서 공유
https://tecoble.techcourse.co.kr/post/2023-08-14-JPA-Cascade/

4. 로그아웃:
- 백에서 하는 줄 알았는데, 프론트에서 AccessToken 삭제하는 거였네요 


<br/>

## 💬리뷰 요구사항(선택)

> 토큰이 Bearer로 전달되어야 하는데  안되있음 (값만 들어가있음) 이건 나중에 따로 하겠슴다
