### PR TITLE
[Feature] meta musicgen 음악 생성 및 DB 저장 구현

### DIFF
--- a/src/main/java/com/kuit/agarang/domain/ai/controller/MemoryAIController.java
+++ b/src/main/java/com/kuit/agarang/domain/ai/controller/MemoryAIController.java
@@ -5,9 +5,11 @@ import com.kuit.agarang.domain.ai.model.dto.TextAnswer;
 import com.kuit.agarang.domain.ai.model.dto.QuestionResponse;
 import com.kuit.agarang.domain.ai.model.entity.cache.GPTChatHistory;
 import com.kuit.agarang.domain.ai.service.AIService;
+import com.kuit.agarang.domain.login.model.dto.CustomOAuth2User;
 import com.kuit.agarang.global.common.model.dto.BaseResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -29,16 +31,18 @@ public class MemoryAIController {
   }
 
   @PostMapping("/second-ans")
-  public ResponseEntity<BaseResponse<Void>> saveLastAnswer(@RequestBody TextAnswer answer) {
+  public ResponseEntity<BaseResponse<Void>> saveLastAnswer(@AuthenticationPrincipal CustomOAuth2User details,
+                                                           @RequestBody TextAnswer answer) {
     AIService.saveLastAnswer(answer);
-    AIService.createMemoryText(answer.getId());
+    AIService.createMemoryText(details.getMemberId(), answer.getId());
     return ResponseEntity.ok(new BaseResponse<>());
   }
 
   @PostMapping("/music")
-  public ResponseEntity<BaseResponse<Void>> saveLastAnswer(@RequestBody MusicAnswer answer) {
+  public ResponseEntity<BaseResponse<Void>> saveLastAnswer(@AuthenticationPrincipal CustomOAuth2User details,
+                                                           @RequestBody MusicAnswer answer) {
     GPTChatHistory chatHistory = AIService.setMusicChoice(answer);
-    AIService.createMusicGenPrompt(chatHistory);
+    AIService.createMusicGenPrompt(details.getMemberId(), chatHistory);
     return ResponseEntity.ok(new BaseResponse<>());
   }
 }

--- a/src/main/java/com/kuit/agarang/domain/ai/controller/MusicGenController.java
+++ b/src/main/java/com/kuit/agarang/domain/ai/controller/MusicGenController.java
@@ -1,0 +1,22 @@
+package com.kuit.agarang.domain.ai.controller;
+
+import com.kuit.agarang.domain.ai.model.dto.musicGen.MusicGenResponse;
+import com.kuit.agarang.domain.ai.service.MusicGenService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/ai/music-gen")
+public class MusicGenController {
+
+  private final MusicGenService musicGenService;
+
+  @PostMapping("/webhook")
+  public void webhook(@RequestBody MusicGenResponse response) {
+    musicGenService.saveMusic(response);
+  }
+}

--- a/src/main/java/com/kuit/agarang/domain/ai/model/dto/MemoryTextInfo.java
+++ b/src/main/java/com/kuit/agarang/domain/ai/model/dto/MemoryTextInfo.java
@@ -1,0 +1,18 @@
+package com.kuit.agarang.domain.ai.model.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MemoryTextInfo {
+  private String babyName;
+  private String familyRole;
+
+  @Builder
+  public MemoryTextInfo(String babyName, String familyRole) {
+    this.babyName = babyName;
+    this.familyRole = familyRole;
+  }
+}

--- a/src/main/java/com/kuit/agarang/domain/ai/model/dto/gpt/GPTImageDescription.java
+++ b/src/main/java/com/kuit/agarang/domain/ai/model/dto/gpt/GPTImageDescription.java
@@ -1,11 +1,14 @@
 package com.kuit.agarang.domain.ai.model.dto.gpt;
 
+import com.kuit.agarang.domain.memory.model.entity.Hashtag;
+import com.kuit.agarang.domain.memory.model.entity.Memory;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Getter
@@ -14,4 +17,9 @@ import java.util.List;
 public class GPTImageDescription {
   private String text;
   private List<String> noun;
+
+  public List<Hashtag> convertNoun(Memory memory) {
+    return this.noun.stream().map(x ->
+      Hashtag.builder().memory(memory).name(x).build()).collect(Collectors.toList());
+  }
 }

--- a/src/main/java/com/kuit/agarang/domain/ai/model/dto/musicGen/MusicGenRequest.java
+++ b/src/main/java/com/kuit/agarang/domain/ai/model/dto/musicGen/MusicGenRequest.java
@@ -1,0 +1,43 @@
+package com.kuit.agarang.domain.ai.model.dto.musicGen;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class MusicGenRequest {
+  private String version;
+  private String webhook;
+  private List<String> webhookEventsFilter;
+  private Input input;
+
+  @Getter
+  @NoArgsConstructor
+  @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+  @Builder
+  @AllArgsConstructor(access = AccessLevel.PROTECTED)
+  public static class Input {
+    private String prompt;
+    private Integer duration;
+    private String modelVersion;
+    private String outputFormat;
+    private String normalizationStrategy;
+  }
+
+  public MusicGenRequest(String version, String webhookUrl, String prompt, Integer duration) {
+    this.version = version;
+    this.webhook = webhookUrl;
+    this.webhookEventsFilter = List.of("completed");
+    this.input = Input.builder()
+      .prompt(prompt)
+      .duration(duration)
+      .modelVersion("stereo-large")
+      .outputFormat("mp3")
+      .normalizationStrategy("peak")
+      .build();
+  }
+}

--- a/src/main/java/com/kuit/agarang/domain/ai/model/dto/musicGen/MusicGenResponse.java
+++ b/src/main/java/com/kuit/agarang/domain/ai/model/dto/musicGen/MusicGenResponse.java
@@ -1,0 +1,18 @@
+package com.kuit.agarang.domain.ai.model.dto.musicGen;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class MusicGenResponse {
+  private String error;
+  private String id;
+  private String output;
+  private String status;
+  private String startedAt;
+  private String completedAt;
+}

--- a/src/main/java/com/kuit/agarang/domain/ai/model/dto/typecast/TypecastRequest.java
+++ b/src/main/java/com/kuit/agarang/domain/ai/model/dto/typecast/TypecastRequest.java
@@ -50,7 +50,7 @@ public class TypecastRequest {
       .xapiHd(true)
       .maxSeconds(60)
       .modelVersion("latest")
-      .xapiAudioFormat("wav")
+      .xapiAudioFormat("mp3")
       .build();
   }
 }

--- a/src/main/java/com/kuit/agarang/domain/ai/model/entity/cache/GPTChatHistory.java
+++ b/src/main/java/com/kuit/agarang/domain/ai/model/entity/cache/GPTChatHistory.java
@@ -19,12 +19,15 @@ public class GPTChatHistory {
   private List<GPTMessage> historyMessages;
   @Setter
   private MusicInfo musicInfo;
+  @Setter
+  private String memoryText;
 
   @Builder
-  public GPTChatHistory(S3File image, GPTImageDescription imageDescription, List<GPTMessage> historyMessages, MusicInfo musicInfo) {
+  public GPTChatHistory(S3File image, GPTImageDescription imageDescription, List<GPTMessage> historyMessages, MusicInfo musicInfo, String memoryText) {
     this.image = image;
     this.imageDescription = imageDescription;
     this.historyMessages = historyMessages;
     this.musicInfo = musicInfo;
+    this.memoryText = memoryText;
   }
 }

--- a/src/main/java/com/kuit/agarang/domain/ai/service/AIService.java
+++ b/src/main/java/com/kuit/agarang/domain/ai/service/AIService.java
@@ -55,7 +55,7 @@ public class AIService {
   private final HashTagRepository hashTagRepository;
 
   public QuestionResponse getFirstQuestion(MultipartFile image) throws Exception {
-    S3File convertedImage = s3FileUtil.uploadTempFile(image);
+    S3File convertedImage = s3FileUtil.convert(image);
 
     // image -> gpt -> 노래제목, 해시태그 생성
     String prompt = promptUtil.createImageDescriptionPrompt();

--- a/src/main/java/com/kuit/agarang/domain/ai/service/AIService.java
+++ b/src/main/java/com/kuit/agarang/domain/ai/service/AIService.java
@@ -203,6 +203,7 @@ public class AIService {
   public String getCharacterBubble(Character character, String familyRole) {
     String prompt = promptUtil.createCharacterBubble(character, familyRole);
     GPTChat chat = gptChatService.chat(GPTSystemRole.ASSISTANT, prompt, 1L, false);
+    logChat(gptUtil.createHistoryMessage(chat));
     return gptUtil.getGPTAnswer(chat);
   }
 

--- a/src/main/java/com/kuit/agarang/domain/ai/service/AIService.java
+++ b/src/main/java/com/kuit/agarang/domain/ai/service/AIService.java
@@ -144,7 +144,7 @@ public class AIService {
 
   @Transactional
   public MemoryTextInfo getMemoryTextInfo(Long memberId) {
-    Member member = memberRepository.findByIdFetchJoinBaby(memberId)
+    Member member = memberRepository.findByIdWithBaby(memberId)
       .orElseThrow(() -> new BusinessException(BaseResponseStatus.NOT_FOUND_MEMBER));
     return MemoryTextInfo.builder()
       .familyRole(member.getFamilyRole())
@@ -193,7 +193,6 @@ public class AIService {
       .build();
 
     List<Hashtag> hashtags = chatHistory.getImageDescription().convertNoun(memory);
-    hashTagRepository.saveAll(hashtags);
     memory.setHashtags(hashtags);
     memoryRepository.save(memory);
 

--- a/src/main/java/com/kuit/agarang/domain/ai/service/MusicGenService.java
+++ b/src/main/java/com/kuit/agarang/domain/ai/service/MusicGenService.java
@@ -1,0 +1,95 @@
+package com.kuit.agarang.domain.ai.service;
+
+import com.kuit.agarang.domain.ai.model.dto.musicGen.MusicGenRequest;
+import com.kuit.agarang.domain.ai.model.dto.musicGen.MusicGenResponse;
+import com.kuit.agarang.domain.ai.utils.MusicGenClientUtil;
+import com.kuit.agarang.domain.memory.model.entity.Memory;
+import com.kuit.agarang.domain.memory.repository.MemoryRepository;
+import com.kuit.agarang.global.common.exception.exception.BusinessException;
+import com.kuit.agarang.global.common.exception.exception.OpenAPIException;
+import com.kuit.agarang.global.common.model.dto.BaseResponseStatus;
+import com.kuit.agarang.global.s3.model.dto.S3File;
+import com.kuit.agarang.global.s3.model.enums.ContentType;
+import com.kuit.agarang.global.s3.utils.S3Util;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MusicGenService {
+
+  @Value("${app.baseUrl}")
+  private String baseUrl;
+  @Value("${music-gen.version}")
+  private String version;
+  private final MusicGenClientUtil musicGenClientUtil;
+  private final S3Util s3Util;
+  private final MemoryRepository memoryRepository;
+
+  private static final String WEBHOOK_URI = "/api/ai/music-gen/webhook";
+  private static final Integer MUSIC_DURATION = 5;
+
+  public String getMusic(String prompt) {
+    MusicGenResponse response
+      = musicGenClientUtil.post(
+      new MusicGenRequest(version, baseUrl + WEBHOOK_URI, prompt, MUSIC_DURATION), MusicGenResponse.class);
+    log.info("created musicgen id : {}", response.getId());
+    return response.getId();
+  }
+
+  public void saveMusic(MusicGenResponse response) {
+    if ("failed".equals(response.getStatus())) {
+      log.info("musicgen error {}", response.getError());
+      throw new OpenAPIException(BaseResponseStatus.FAIL_CREATE_MUSIC);
+    }
+    log.info("webhook musicgen id : {}", response.getId());
+    log.info("webhook musicgen started at : {}", response.getStartedAt());
+    log.info("webhook musicgen completed at : {}", response.getCompletedAt());
+
+    S3File s3File = null;
+    try {
+      Path directoryPath = Paths.get("./temp/audio");
+      if (!Files.exists(directoryPath)) {
+        Files.createDirectories(directoryPath);
+      }
+
+      String filename = "music_gen_" + System.currentTimeMillis() + ".mp3";
+      Path tempFilePath = directoryPath.resolve(filename);
+
+      URL url = new URL(response.getOutput());
+      Files.copy(url.openStream(), tempFilePath, StandardCopyOption.REPLACE_EXISTING);
+      log.info("파일 다운로드 완료: {}", tempFilePath.toString());
+
+      s3File = S3File.builder()
+        .filename(ContentType.MP3.getPath() + filename)
+        .contentType(ContentType.MP3)
+        .contentLength(Files.size(tempFilePath))
+        .bytes(Files.readAllBytes(tempFilePath))
+        .build();
+      s3File = s3Util.upload(s3File);
+    } catch (IOException e) {
+      throw new BusinessException(BaseResponseStatus.FILE_DOWNLOAD_ERROR);
+    }
+
+    Optional<Memory> optionalMemory = memoryRepository.findByMusicGenId(response.getId());
+    if (optionalMemory.isEmpty()) {
+      log.info("memory empty and musicgen output url : {}", response.getOutput());
+      log.error("music gen webhook error : not found member by musicgenId");
+      return;
+    }
+    Memory memory = optionalMemory.get();
+    memory.setMusicUrl(s3File.getObjectUrl());
+    memoryRepository.save(memory);
+  }
+}

--- a/src/main/java/com/kuit/agarang/domain/ai/service/MusicGenService.java
+++ b/src/main/java/com/kuit/agarang/domain/ai/service/MusicGenService.java
@@ -45,7 +45,7 @@ public class MusicGenService {
 
     Optional<Memory> optionalMemory = memoryRepository.findByMusicGenId(response.getId());
     if (optionalMemory.isEmpty()) {
-      log.info("music gen webhook error : not found member by musicgenId : {}", response.getId());
+      log.error("music gen webhook error : not found member by musicgenId : {}", response.getId());
       return;
     }
 

--- a/src/main/java/com/kuit/agarang/domain/ai/service/TypecastService.java
+++ b/src/main/java/com/kuit/agarang/domain/ai/service/TypecastService.java
@@ -33,6 +33,7 @@ public class TypecastService {
   }
 
   public void saveAudio(TypecastWebhookResponse response) {
+    log.info("tts webhook : {}", response.getSpeakUrl());
     if ("failed".equals(response.getStatus())) {
       throw new OpenAPIException(BaseResponseStatus.NOT_FOUND_TSS_AUDIO);
     }

--- a/src/main/java/com/kuit/agarang/domain/ai/utils/GPTPromptUtil.java
+++ b/src/main/java/com/kuit/agarang/domain/ai/utils/GPTPromptUtil.java
@@ -1,5 +1,6 @@
 package com.kuit.agarang.domain.ai.utils;
 
+import com.kuit.agarang.domain.ai.model.dto.MemoryTextInfo;
 import com.kuit.agarang.domain.ai.model.dto.MusicInfo;
 import com.kuit.agarang.domain.ai.model.dto.gpt.GPTImageDescription;
 import com.kuit.agarang.domain.baby.model.entity.Character;
@@ -23,10 +24,10 @@ public class GPTPromptUtil {
       .append("말투는 아이가 부모님에게 묻는 말투로 해줘. ").toString();
   }
 
-  public String createMemoryTextPrompt(String babyName, String familyRole) {
-    return new StringBuilder("위의 대화는 오늘 ").append(familyRole).append("에게 있었던 일이야. ")
-      .append(familyRole).append("에게 있었던 일을 기반으로 ")
-      .append(familyRole).append("가 태아인 ").append(babyName).append("에게 편지를 작성할거야. ")
+  public String createMemoryTextPrompt(MemoryTextInfo info) {
+    return new StringBuilder("위의 대화는 오늘 ").append(info.getFamilyRole()).append("에게 있었던 일이야. ")
+      .append(info.getFamilyRole()).append("에게 있었던 일을 기반으로 ")
+      .append(info.getFamilyRole()).append("가 태아인 ").append(info.getBabyName()).append("에게 편지를 작성할거야. ")
       .append("위의 대화를 바탕으로 일상 태담을 5문장 정도로 감성적으로 작성해줘.").toString();
   }
 

--- a/src/main/java/com/kuit/agarang/domain/ai/utils/MusicGenClientUtil.java
+++ b/src/main/java/com/kuit/agarang/domain/ai/utils/MusicGenClientUtil.java
@@ -1,0 +1,20 @@
+package com.kuit.agarang.domain.ai.utils;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MusicGenClientUtil {
+
+  private final WebClientUtil webClientUtil;
+  @Value("${music-gen.baseUrl}")
+  private String baseUrl;
+  @Value("${music-gen.apiKey}")
+  private String apiKey;
+
+  public <T, V> T post(V requestDto, Class<T> responseClass) {
+    return webClientUtil.post(baseUrl, apiKey, requestDto, responseClass);
+  }
+}

--- a/src/main/java/com/kuit/agarang/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/kuit/agarang/domain/member/repository/MemberRepository.java
@@ -11,6 +11,9 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
   Optional<Member> findByProviderId(String providerId);
 
+  @Query("SELECT m FROM Member m JOIN FETCH m.baby WHERE m.id = :memberId")
+  Optional<Member> findByIdWithBaby(@Param("memberId") Long memberId);
+
   @Query("SELECT m FROM Member m JOIN FETCH Baby b ON m.baby = b WHERE m.id = :memberId")
   Optional<Member> findByIdFetchJoinBaby(@Param("memberId") Long memberId);
 

--- a/src/main/java/com/kuit/agarang/domain/memory/model/dto/MemoryDTO.java
+++ b/src/main/java/com/kuit/agarang/domain/memory/model/dto/MemoryDTO.java
@@ -37,7 +37,7 @@ public class MemoryDTO {
             .date(DateUtil.formatLocalDateTime(memory.getCreatedAt(), "yyyy. MM. dd"))
             .content(memory.getText())
             .musicUrl(memory.getMusicUrl())
-            .hashTags(memory.getHashtag().stream()
+            .hashTags(memory.getHashtags().stream()
                     .map(Hashtag::getName)
                     .toList())
             .imageUrl(memory.getImageUrl())

--- a/src/main/java/com/kuit/agarang/domain/memory/model/entity/Hashtag.java
+++ b/src/main/java/com/kuit/agarang/domain/memory/model/entity/Hashtag.java
@@ -2,7 +2,10 @@ package com.kuit.agarang.domain.memory.model.entity;
 
 import com.kuit.agarang.global.common.model.entity.BaseEntity;
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
@@ -20,7 +23,9 @@ public class Hashtag extends BaseEntity {
   private String name; // 해시태그 명
 
   @Builder
-  public Hashtag(String name) {
+  public Hashtag(Long id, Memory memory, String name) {
+    this.id = id;
+    this.memory = memory;
     this.name = name;
   }
 }

--- a/src/main/java/com/kuit/agarang/domain/memory/model/entity/Memory.java
+++ b/src/main/java/com/kuit/agarang/domain/memory/model/entity/Memory.java
@@ -1,13 +1,13 @@
 package com.kuit.agarang.domain.memory.model.entity;
 
 
-import com.kuit.agarang.global.common.model.entity.BaseEntity;
 import com.kuit.agarang.domain.baby.model.entity.Baby;
 import com.kuit.agarang.domain.member.model.entity.Member;
 import com.kuit.agarang.domain.memory.enums.Genre;
 import com.kuit.agarang.domain.memory.enums.Instrument;
 import com.kuit.agarang.domain.memory.enums.Mood;
 import com.kuit.agarang.domain.memory.enums.Tempo;
+import com.kuit.agarang.global.common.model.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -32,8 +32,12 @@ public class Memory extends BaseEntity {
 
   private String imageUrl;
   private String musicTitle;
-  private String musicUrl;
   private String text;
+
+  @Setter
+  private String musicGenId;
+  @Setter
+  private String musicUrl;
 
   @Enumerated(EnumType.STRING)
   private Genre genre;
@@ -47,20 +51,25 @@ public class Memory extends BaseEntity {
   @Enumerated(EnumType.STRING)
   private Instrument instrument;
 
+  @Setter
   @OneToMany(mappedBy = "memory")
-  private List<Hashtag> hashtag;
+  private List<Hashtag> hashtags;
 
   @Builder
-  public Memory(String imageUrl, String musicTitle, String musicUrl, String text, Genre genre,
-                Mood mood, Tempo tempo, Instrument instrument) {
+  public Memory(Long id, Member member, Baby baby, String imageUrl, String musicTitle, String musicUrl, String text, String musicGenId, Genre genre, Mood mood, Tempo tempo, Instrument instrument, List<Hashtag> hashtags) {
+    this.id = id;
+    this.member = member;
+    this.baby = baby;
     this.imageUrl = imageUrl;
     this.musicTitle = musicTitle;
     this.musicUrl = musicUrl;
     this.text = text;
+    this.musicGenId = musicGenId;
     this.genre = genre;
     this.mood = mood;
     this.tempo = tempo;
     this.instrument = instrument;
+    this.hashtags = hashtags;
   }
 
   public void updateMemory(String text) {

--- a/src/main/java/com/kuit/agarang/domain/memory/model/entity/Memory.java
+++ b/src/main/java/com/kuit/agarang/domain/memory/model/entity/Memory.java
@@ -10,6 +10,7 @@ import com.kuit.agarang.domain.memory.enums.Tempo;
 import com.kuit.agarang.global.common.model.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.BatchSize;
 
 import java.util.List;
 
@@ -52,7 +53,8 @@ public class Memory extends BaseEntity {
   private Instrument instrument;
 
   @Setter
-  @OneToMany(mappedBy = "memory")
+  @OneToMany(mappedBy = "memory", cascade = CascadeType.ALL, orphanRemoval = true)
+  @BatchSize(size = 3)
   private List<Hashtag> hashtags;
 
   @Builder

--- a/src/main/java/com/kuit/agarang/domain/memory/repository/MemoryRepository.java
+++ b/src/main/java/com/kuit/agarang/domain/memory/repository/MemoryRepository.java
@@ -1,7 +1,6 @@
 package com.kuit.agarang.domain.memory.repository;
 
 import com.kuit.agarang.domain.baby.model.entity.Baby;
-import com.kuit.agarang.domain.member.model.entity.Member;
 import com.kuit.agarang.domain.memory.model.dto.MemoryBookmarkedDTO;
 import com.kuit.agarang.domain.memory.model.entity.Memory;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -29,4 +28,6 @@ public interface MemoryRepository extends JpaRepository<Memory,Long> {
   List<Memory> findTop3ByBabyOrderByCreatedAtDesc(Baby baby); // 3개 이하 시 조회된 갯수 만큼만 반환
   Optional<Memory> findByIdAndMemberId(Long memoryId, Long memberId);
   List<Memory> findByMemberId(Long memberId);
+
+  Optional<Memory> findByMusicGenId(String musicGenId);
 }

--- a/src/main/java/com/kuit/agarang/domain/playlist/model/dto/MusicDto.java
+++ b/src/main/java/com/kuit/agarang/domain/playlist/model/dto/MusicDto.java
@@ -32,7 +32,7 @@ public class MusicDto {
                 .imageUrl(memory.getImageUrl())
                 .musicTitle(memory.getMusicTitle())
                 .musicUrl(memory.getMusicUrl())
-                .hashTags(memory.getHashtag().stream()
+                .hashTags(memory.getHashtags().stream()
                         .map(Hashtag::getName)
                         .toList())
                 .isBookmarked(isBookmarked)

--- a/src/main/java/com/kuit/agarang/global/common/model/dto/BaseResponseStatus.java
+++ b/src/main/java/com/kuit/agarang/global/common/model/dto/BaseResponseStatus.java
@@ -15,26 +15,25 @@ public enum BaseResponseStatus {
 
   INVALID_MEMORY_ID(false, HttpStatus.NOT_FOUND, 4001, "존재하지 않는 추억입니다."),
   FILE_TOO_LARGE(false, HttpStatus.PAYLOAD_TOO_LARGE, 4002, "최대 파일 사이즈(1MB)를 초과했습니다."),
-
-  NOT_FOUND_BABY(false, HttpStatus.NOT_FOUND, 4021, "아기를 찾을 수 없습니다"),
-  NOT_FOUND_CHARACTER(false, HttpStatus.NOT_FOUND, 4022, "캐릭터를 찾을 수 없습니다"),
-  NOT_FOUND_MEMBER(false, HttpStatus.NOT_FOUND, 4023, "사용자를 찾을 수 없습니다"),
-  NOT_FOUND_REFRESH_TOKEN(false, HttpStatus.NOT_FOUND, 4024, "리프레시 토큰을 찾을 수 없습니다"),
-  EXPIRED_REFRESH_TOKEN(false, HttpStatus.NOT_FOUND, 4025, "리프레시 토큰이 만료되었습니다."),
-
   INVALID_FILE_EXTENSION(false, HttpStatus.BAD_REQUEST, 4003, "지원하지 않는 파일확장자입니다."),
   NOT_FOUND_RESOURCE(false, HttpStatus.NOT_FOUND, 4004, "존재하지 않는 페이지입니다."),
   NOT_FOUND_S3_FILE(false, HttpStatus.NOT_FOUND, 4005, "S3 파일 서버에 이미지 URL과 일치하는 파일이 존재하지 않습니다."),
   NOT_FOUND_TSS_AUDIO(false, HttpStatus.NOT_FOUND, 4006, "TTS 오디오 생성 및 저장에 문제가 발생했습니다."),
   NOT_FOUND_HISTORY_CHAT(false, HttpStatus.NOT_FOUND, 4007, "카드 생성 중 이전 대화기록을 찾을 수 없습니다. id 값을 확인해주세요."),
   INVALID_MUSIC_CHOICE(false, HttpStatus.BAD_REQUEST, 4008, "음악 선택값이 올바른지 확인해주세요."),
-  INVALID_MEMBER_ID(false, HttpStatus.NOT_FOUND, 4009, "존재하지 않는 회원입니다."),
-  INVALID_PLAYLIST_ID(false, HttpStatus.NOT_FOUND, 4010, "존재하지 않는 플레이리스트입니다."),
+  FAIL_FILE_READ(false, HttpStatus.FORBIDDEN, 4009, "파일 업로드에 실패했습니다. 다시 시도해주세요."),
+  INVALID_MEMBER_ID(false, HttpStatus.NOT_FOUND, 40010, "존재하지 않는 회원입니다."),
+  INVALID_PLAYLIST_ID(false, HttpStatus.NOT_FOUND, 4011, "존재하지 않는 플레이리스트입니다."),
+  NOT_FOUND_BABY(false, HttpStatus.NOT_FOUND, 4012, "아기를 찾을 수 없습니다"),
+  NOT_FOUND_CHARACTER(false, HttpStatus.NOT_FOUND, 4013, "캐릭터를 찾을 수 없습니다"),
+  NOT_FOUND_MEMBER(false, HttpStatus.NOT_FOUND, 4014, "사용자를 찾을 수 없습니다"),
+  NOT_FOUND_REFRESH_TOKEN(false, HttpStatus.NOT_FOUND, 4015, "리프레시 토큰을 찾을 수 없습니다"),
+  EXPIRED_REFRESH_TOKEN(false, HttpStatus.NOT_FOUND, 4016, "리프레시 토큰이 만료되었습니다."),
 
   SERVER_ERROR(false, HttpStatus.INTERNAL_SERVER_ERROR, 5001, "알 수 없는 이유로 서버에 문제가 발생했습니다."),
   FAIL_REDIS_CONNECTION(false, HttpStatus.SERVICE_UNAVAILABLE, 5002, "레디스 서버에 연결 실패했습니다."),
   FAIL_S3_UPLOAD(false, HttpStatus.SERVICE_UNAVAILABLE, 5003, "S3 파일 서버 업로드에 실패했습니다."),
-  INVALID_GPT_RESPONSE(false, HttpStatus.INTERNAL_SERVER_ERROR, 5004, "GPT 응답이 유효하지 않습니다.")
+  INVALID_GPT_RESPONSE(false, HttpStatus.INTERNAL_SERVER_ERROR, 5004, "GPT 응답이 유효하지 않습니다.");
 
   ;
 

--- a/src/main/java/com/kuit/agarang/global/common/model/dto/BaseResponseStatus.java
+++ b/src/main/java/com/kuit/agarang/global/common/model/dto/BaseResponseStatus.java
@@ -29,13 +29,13 @@ public enum BaseResponseStatus {
   NOT_FOUND_MEMBER(false, HttpStatus.NOT_FOUND, 4014, "사용자를 찾을 수 없습니다"),
   NOT_FOUND_REFRESH_TOKEN(false, HttpStatus.NOT_FOUND, 4015, "리프레시 토큰을 찾을 수 없습니다"),
   EXPIRED_REFRESH_TOKEN(false, HttpStatus.NOT_FOUND, 4016, "리프레시 토큰이 만료되었습니다."),
+  FILE_DOWNLOAD_ERROR(false, HttpStatus.FORBIDDEN, 4017, "musicgen 파일 다운로드 중 오류가 발생했습니다."),
 
   SERVER_ERROR(false, HttpStatus.INTERNAL_SERVER_ERROR, 5001, "알 수 없는 이유로 서버에 문제가 발생했습니다."),
   FAIL_REDIS_CONNECTION(false, HttpStatus.SERVICE_UNAVAILABLE, 5002, "레디스 서버에 연결 실패했습니다."),
   FAIL_S3_UPLOAD(false, HttpStatus.SERVICE_UNAVAILABLE, 5003, "S3 파일 서버 업로드에 실패했습니다."),
-  INVALID_GPT_RESPONSE(false, HttpStatus.INTERNAL_SERVER_ERROR, 5004, "GPT 응답이 유효하지 않습니다.");
-
-  ;
+  INVALID_GPT_RESPONSE(false, HttpStatus.INTERNAL_SERVER_ERROR, 5004, "GPT 응답이 유효하지 않습니다."),
+  FAIL_CREATE_MUSIC(false, HttpStatus.INTERNAL_SERVER_ERROR, 5005, "music gen 음악 생성에 실패했습니다.");
 
 
   private final boolean isSuccess;

--- a/src/main/java/com/kuit/agarang/global/s3/model/dto/S3File.java
+++ b/src/main/java/com/kuit/agarang/global/s3/model/dto/S3File.java
@@ -38,4 +38,9 @@ public class S3File {
     this.bytes = null;
     return this;
   }
+
+  public S3File chargeBytes(byte[] bytes) {
+    this.bytes = bytes;
+    return this;
+  }
 }

--- a/src/main/java/com/kuit/agarang/global/s3/model/dto/S3File.java
+++ b/src/main/java/com/kuit/agarang/global/s3/model/dto/S3File.java
@@ -33,14 +33,4 @@ public class S3File {
     String base64EncodeData = Base64.getEncoder().encodeToString(this.getBytes());
     return "data:" + this.getContentType().getMimeType() + ";base64," + base64EncodeData;
   }
-
-  public S3File cleanBytes() {
-    this.bytes = null;
-    return this;
-  }
-
-  public S3File chargeBytes(byte[] bytes) {
-    this.bytes = bytes;
-    return this;
-  }
 }

--- a/src/main/java/com/kuit/agarang/global/s3/utils/S3FileUtil.java
+++ b/src/main/java/com/kuit/agarang/global/s3/utils/S3FileUtil.java
@@ -11,7 +11,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.Optional;
@@ -50,10 +49,12 @@ public class S3FileUtil {
       if (file.createNewFile()) {
         try (FileOutputStream fos = new FileOutputStream(file)) {
           fos.write(s3File.getBytes());
+        } catch (IOException e) {
+          throw new FileException(BaseResponseStatus.FAIL_FILE_READ);
         }
       }
     } catch (IOException e) {
-      throw new FileException(BaseResponseStatus.FAIL_FILE_READ);
+      log.info("파일 생성 실패");
     }
   }
 
@@ -65,20 +66,6 @@ public class S3FileUtil {
         return;
       }
       log.info("임시 업로드 파일 삭제를 실패했습니다. [{}]", file.getPath());
-    }
-  }
-
-  public S3File getTempFile(S3File s3File) {
-    File file = new File(tempPath, s3File.getFilename());
-    if (!file.exists()) {
-      uploadTempFile(s3File);
-      return s3File;
-    }
-
-    try (FileInputStream fis = new FileInputStream(file)) {
-      return s3File.chargeBytes(fis.readAllBytes());
-    } catch (IOException e) {
-      throw new FileException(BaseResponseStatus.FAIL_FILE_READ);
     }
   }
 

--- a/src/main/java/com/kuit/agarang/global/s3/utils/S3Util.java
+++ b/src/main/java/com/kuit/agarang/global/s3/utils/S3Util.java
@@ -27,9 +27,13 @@ public class S3Util {
   @Value("${aws.s3.bucket}")
   private String bucket;
 
-  public S3File upload(MultipartFile file) throws Exception {
+  public S3File upload(MultipartFile file) {
     log.info("S3 파일 업로드가 시작되었습니다. [{} of {}]", file.getOriginalFilename(), file.getContentType());
-    S3File s3File = s3FileUtil.uploadTempFile(file);
+    return upload(s3FileUtil.convert(file));
+  }
+
+  public S3File downloadAudioAndUpload(String url) {
+    S3File s3File = s3FileUtil.downloadAudioUrl(url);
     return upload(s3File);
   }
 
@@ -48,8 +52,6 @@ public class S3Util {
     } catch (Exception e) {
       e.printStackTrace();
       throw new FileException(BaseResponseStatus.FAIL_S3_UPLOAD);
-    } finally {
-      s3FileUtil.deleteTempFile(s3File);
     }
   }
 

--- a/src/main/java/com/kuit/agarang/global/s3/utils/S3Util.java
+++ b/src/main/java/com/kuit/agarang/global/s3/utils/S3Util.java
@@ -33,7 +33,7 @@ public class S3Util {
     return upload(s3File);
   }
 
-  private S3File upload(S3File s3File) {
+  public S3File upload(S3File s3File) {
     try {
       PutObjectRequest request = PutObjectRequest.builder()
         .bucket(bucket)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,9 +14,13 @@ spring:
       ddl-auto: update
     properties:
       hibernate:
-        show_sql: true
         format_sql: true
-    open-in-view: true
+
+logging:
+  level:
+    org:
+      hibernate:
+        sql: debug
 
   data:
     redis:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,12 +16,6 @@ spring:
       hibernate:
         format_sql: true
 
-logging:
-  level:
-    org:
-      hibernate:
-        sql: debug
-
   data:
     redis:
       repositories:
@@ -29,6 +23,12 @@ logging:
     jpa:
       repositories:
         bootstrap-mode: deferred
+
+logging:
+  level:
+    org:
+      hibernate:
+        sql: debug
 
 aws:
   s3:

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -2,9 +2,9 @@
 DELETE FROM memory_playlist;
 DELETE FROM memory_bookmark;
 DELETE FROM music_bookmark;
-DELETE FROM hashtag;
 
 DELETE FROM playlist;
+DELETE FROM hashtag;
 DELETE FROM memory;
 DELETE FROM member;
 DELETE FROM baby;
@@ -58,12 +58,12 @@ VALUES
 -- Insert new hashtag records
 INSERT INTO hashtag (id, created_at, updated_at, status, name, memory_id)
 VALUES
-    (1, '2024-07-01 00:00:00', '2024-07-01 00:00:00', 'ACTIVE', 'HAPPY', 1),
-    (2, '2024-07-01 00:00:00', '2024-07-01 00:00:00', 'ACTIVE', 'BEAUTIFUL', 2),
-    (3, '2024-07-01 00:00:00', '2024-07-01 00:00:00', 'ACTIVE', 'LOVELY', 3);
+    (1, '2024-07-01 00:00:00', '2024-07-01 00:00:00', 'ACTIVE', '여름', 1),
+    (2, '2024-07-01 00:00:00', '2024-07-01 00:00:00', 'ACTIVE', '바다', 1),
+    (3, '2024-07-01 00:00:00', '2024-07-01 00:00:00', 'ACTIVE', '파도', 1);
 
 -- Insert new memoryplaylist records
-INSERT INTO memory_playlist (id, created_at, updated_at, status, memory_id,playlist_id)
+INSERT INTO memory_playlist (id, created_at, updated_at, status, memory_id, playlist_id)
 VALUES
     (1, '2024-07-01 00:00:00', '2024-07-01 00:00:00', 'ACTIVE', 1, 1),
     (2, '2024-07-01 00:00:00', '2024-07-01 00:00:00', 'ACTIVE', 1, 5),

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -9,6 +9,14 @@
         </encoder>
     </appender>
 
+    <!--Hibernate SQL 로깅 설정 추가-->
+    <logger name="org.hibernate.SQL" level="DEBUG" additivity="false">
+        <appender-ref ref="Console"/>
+    </logger>
+    <logger name="org.hibernate.type.descriptor.sql.BasicBinder" level="TRACE" additivity="false">
+        <appender-ref ref="Console"/>
+    </logger>
+
     <!--Local : 콘솔O 디스코드 알림X-->
     <springProfile name="local">
         <include resource="console-appender.xml"/>


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

#### 👾 S3FileUtil 클래스 내에서 예외 처리

외부 서비스에서 throws IOException 등을 추가하지 않고도 내부에서 예외를 처리할 수 있도록 try-catch 문을 활용합니다.

<br/>

#### ✨ 회원 기반 프롬포트 생성

jwtFilter 를 활용하여 회원에 대한 정보를 컨트롤러에서 받아 프롬포트 생성 시 활용합니다.

<br/>

#### 👾 로컬 파일 조회 메서드 삭제

로컬에 올려둔 파일을 읽어오는 메서드를 구현했으나 활용할 일이 없을 것 같아 삭제했습니다.

<br/>

#### ✨ 해시태그 타입 변환

gpt 대화를 통해 해시태그를 `List<String>` 으로 레디스에 저장해두었습니다.

이를 다시 memory 엔티티에 맞추어 `List<Hashtag>` 로 변환합니다.

<br/>

#### ✨ 음악 생성 로직

예를 들어 아래와 같은 프롬포트로 음악을 생성합니다.

```
A serene R&B track with gentle piano melodies, capturing the essence of a peaceful beach scene with clear skies, transparent waters, and soft sand. The beautiful harmonies and smooth rhythms perfectly convey a sense of tranquility and beauty.
```

<br/>

처음 post 요청 시 아래 고유 아이디 값을 반환받을 수 있습니다.

```
7ap27d5c85rj20ch7qev61xaxw
```

<br/>

일정 시간 뒤 음악이 생성되면 webhook 으로 결과값이 반환됩니다. 이때 아이디 값이 처음 post 요청 시 받은 아이디값과 동일합니다.

따라서 member 엔티티에 musicGenId 필드를 추가하여 생성된 음악 저장 시에 사용합니다.

```
webhook musicgen id : 7ap27d5c85rj20ch7qev61xaxw
```

<br/>

[노래 들어보기1](https://agarang-s3-bucket.s3.ap-northeast-2.amazonaws.com/audio/music_gen_1723319836326.mp3)
[노래 들어보기2](https://agarang-s3-bucket.s3.ap-northeast-2.amazonaws.com/audio/music_gen_1723314306702.mp3)
[노래 들어보기3](https://agarang-s3-bucket.s3.ap-northeast-2.amazonaws.com/audio/music_gen_1723313836428.mp3)
[노래 들어보기4](https://agarang-s3-bucket.s3.ap-northeast-2.amazonaws.com/audio/out.mp3)


<br/>

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

pr 단위가 크다보니 질문 완전 환영입니다! 

추가로 현재 타입캐스트 테스트 기간이 끝나서 오디오 생성 시 문제가 발생하고 있습니다. PM 님께서 월요일에 답변 받으면 알려주신다네요.

그리고 음악 생성 시 요금 발생을 우려하여 우선 5초로 설정해두었고, 이후 연동 모두 완료되면 40초로 변경할 예정입니다.
