### PR TITLE
[Feature] 플레이리스트 구분 저장을 위한 Util 구현

### DIFF
--- a/src/main/java/com/kuit/agarang/domain/ai/service/AIService.java
+++ b/src/main/java/com/kuit/agarang/domain/ai/service/AIService.java
@@ -208,17 +208,9 @@ public class AIService {
     memoryRepository.save(memory);
 
     // TODO : playlist 구분 저장 구현 시 반영
-    List<Long> playlistIds = musicSaveUtil.getPlaylistIds(chatHistory.getMusicInfo().getGenre(),
-            chatHistory.getMusicInfo().getMood(),
-            chatHistory.getMusicInfo().getInstrument());
+    List<Playlist> playlists = musicSaveUtil.getPlaylistIds(memory.getGenre(), memory.getMood(), memory.getInstrument());
 
-    for (Long playlistId : playlistIds) {
-      Playlist playlist = playlistRepository.findById(playlistId)
-              .orElseThrow(() -> new BusinessException(BaseResponseStatus.INVALID_PLAYLIST_ID));
-
-      MemoryPlaylist memoryPlaylist = new MemoryPlaylist(memory, playlist);
-      memoryPlaylistRepository.save(memoryPlaylist);
-    }
+    playlists.forEach(x -> memoryPlaylistRepository.save(new MemoryPlaylist(memory, x)));
   }
 
   public String getCharacterBubble(Character character, String familyRole) {

--- a/src/main/java/com/kuit/agarang/domain/memory/enums/Instrument.java
+++ b/src/main/java/com/kuit/agarang/domain/memory/enums/Instrument.java
@@ -2,5 +2,5 @@ package com.kuit.agarang.domain.memory.enums;
 
 public enum Instrument {
   PIANO, VIOLIN, FLUTE, CLARINET, BASE_GUITAR, ELECTRIC_GUITAR,
-  HARP, TRUMPET, SAXOPHONE, VIOLA, CELLO, XYLOPHONE
+  HARP, TRUMPET, SAXOPHONE, VIOLA, CELLO, XYLOPHONE, DRUM
 }

--- a/src/main/java/com/kuit/agarang/domain/playlist/util/MusicSaveUtil.java
+++ b/src/main/java/com/kuit/agarang/domain/playlist/util/MusicSaveUtil.java
@@ -1,0 +1,67 @@
+package com.kuit.agarang.domain.playlist.util;
+
+import com.kuit.agarang.domain.memory.enums.Genre;
+import com.kuit.agarang.domain.memory.enums.Instrument;
+import com.kuit.agarang.domain.memory.enums.Mood;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Component
+public class MusicSaveUtil {
+
+    public List<Long> getPlaylistIds(Genre genre, Mood mood, Instrument instrument) {
+        List<Long> playlistIds = new ArrayList<>();
+
+        //1. 전체 플레이리스트
+        playlistIds.add(1L);
+
+        // 3. 태동이 느껴질 때 듣는
+        if( mood == Mood.LOVELY || mood == Mood.BEAUTIFUL ||
+                genre == Genre.BALLAD || genre == Genre.ACOUSTIC ||
+                instrument == Instrument.HARP || instrument == Instrument.VIOLIN || instrument == Instrument.PIANO){
+            playlistIds.add(3L);
+        }
+
+        // 4. 하루를 정리하며 듣는
+        if (mood == Mood.BRIGHT || mood == Mood.PEACEFUL ||
+                genre == Genre.POP || genre == Genre.INDIE ||
+                instrument == Instrument.XYLOPHONE || instrument == Instrument.TRUMPET || instrument == Instrument.FLUTE) {
+            playlistIds.add(4L);
+        }
+
+        // 5. 아침을 시작하며 듣는
+        if (mood == Mood.HAPPY || mood == Mood.WARM ||
+                genre == Genre.JAZZ || genre == Genre.ACOUSTIC ||
+                instrument == Instrument.SAXOPHONE || instrument == Instrument.PIANO || instrument == Instrument.FLUTE) {
+            playlistIds.add(5L);
+        }
+
+        // 6. 운동하며 듣는
+        if (mood == Mood.ENERGETIC ||
+                genre == Genre.ROCK || genre == Genre.ELECTRONIC || genre == Genre.HIPHOP ||
+                instrument == Instrument.ELECTRIC_GUITAR || instrument == Instrument.DRUM || instrument == Instrument.TRUMPET) {
+            playlistIds.add(6L);
+        }
+
+        // 7. 마음을 편안하게 하는
+        if (mood == Mood.FANTASTIC || mood == Mood.PEACEFUL ||
+                genre == Genre.ACOUSTIC || genre == Genre.INDIE ||
+                instrument == Instrument.FLUTE || instrument == Instrument.XYLOPHONE || instrument == Instrument.VIOLIN) {
+            playlistIds.add(7L);
+        }
+
+        // 8. 혼자만의 시간을 가지며 듣는
+        if (mood == Mood.TOUCHING ||
+                genre == Genre.RNB || genre == Genre.BALLAD ||
+                instrument == Instrument.CELLO || instrument == Instrument.PIANO || instrument == Instrument.HARP) {
+            playlistIds.add(8L);
+        }
+
+
+        return playlistIds;
+    }
+}

--- a/src/main/java/com/kuit/agarang/domain/playlist/util/MusicSaveUtil.java
+++ b/src/main/java/com/kuit/agarang/domain/playlist/util/MusicSaveUtil.java
@@ -3,6 +3,11 @@ package com.kuit.agarang.domain.playlist.util;
 import com.kuit.agarang.domain.memory.enums.Genre;
 import com.kuit.agarang.domain.memory.enums.Instrument;
 import com.kuit.agarang.domain.memory.enums.Mood;
+import com.kuit.agarang.domain.playlist.model.entity.Playlist;
+import com.kuit.agarang.domain.playlist.repository.PlaylistRepository;
+import com.kuit.agarang.global.common.exception.exception.BusinessException;
+import com.kuit.agarang.global.common.model.dto.BaseResponseStatus;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
@@ -11,57 +16,64 @@ import java.util.List;
 
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class MusicSaveUtil {
 
-    public List<Long> getPlaylistIds(Genre genre, Mood mood, Instrument instrument) {
-        List<Long> playlistIds = new ArrayList<>();
+    private final PlaylistRepository playlistRepository;
+
+    public List<Playlist> getPlaylistIds(Genre genre, Mood mood, Instrument instrument) {
+        List<Playlist> playlists = new ArrayList<>();
 
         //1. 전체 플레이리스트
-        playlistIds.add(1L);
+        playlists.add(getPlaylist(1L));
 
         // 3. 태동이 느껴질 때 듣는
         if( mood == Mood.LOVELY || mood == Mood.BEAUTIFUL ||
                 genre == Genre.BALLAD || genre == Genre.ACOUSTIC ||
                 instrument == Instrument.HARP || instrument == Instrument.VIOLIN || instrument == Instrument.PIANO){
-            playlistIds.add(3L);
+            playlists.add(getPlaylist(3L));
         }
 
         // 4. 하루를 정리하며 듣는
         if (mood == Mood.BRIGHT || mood == Mood.PEACEFUL ||
                 genre == Genre.POP || genre == Genre.INDIE ||
                 instrument == Instrument.XYLOPHONE || instrument == Instrument.TRUMPET || instrument == Instrument.FLUTE) {
-            playlistIds.add(4L);
+            playlists.add(getPlaylist(4L));
         }
 
         // 5. 아침을 시작하며 듣는
         if (mood == Mood.HAPPY || mood == Mood.WARM ||
                 genre == Genre.JAZZ || genre == Genre.ACOUSTIC ||
                 instrument == Instrument.SAXOPHONE || instrument == Instrument.PIANO || instrument == Instrument.FLUTE) {
-            playlistIds.add(5L);
+            playlists.add(getPlaylist(5L));
         }
 
         // 6. 운동하며 듣는
         if (mood == Mood.ENERGETIC ||
                 genre == Genre.ROCK || genre == Genre.ELECTRONIC || genre == Genre.HIPHOP ||
                 instrument == Instrument.ELECTRIC_GUITAR || instrument == Instrument.DRUM || instrument == Instrument.TRUMPET) {
-            playlistIds.add(6L);
+            playlists.add(getPlaylist(6L));
         }
 
         // 7. 마음을 편안하게 하는
         if (mood == Mood.FANTASTIC || mood == Mood.PEACEFUL ||
                 genre == Genre.ACOUSTIC || genre == Genre.INDIE ||
                 instrument == Instrument.FLUTE || instrument == Instrument.XYLOPHONE || instrument == Instrument.VIOLIN) {
-            playlistIds.add(7L);
+            playlists.add(getPlaylist(7L));
         }
 
         // 8. 혼자만의 시간을 가지며 듣는
         if (mood == Mood.TOUCHING ||
                 genre == Genre.RNB || genre == Genre.BALLAD ||
                 instrument == Instrument.CELLO || instrument == Instrument.PIANO || instrument == Instrument.HARP) {
-            playlistIds.add(8L);
+            playlists.add(getPlaylist(8L));
         }
 
+        return playlists;
+    }
 
-        return playlistIds;
+    private Playlist getPlaylist(Long playlistId) {
+        return playlistRepository.findById(playlistId)
+                .orElseThrow(() -> new BusinessException(BaseResponseStatus.INVALID_PLAYLIST_ID));
     }
 }

--- a/src/main/java/com/kuit/agarang/global/common/model/dto/BaseResponseStatus.java
+++ b/src/main/java/com/kuit/agarang/global/common/model/dto/BaseResponseStatus.java
@@ -22,7 +22,7 @@ public enum BaseResponseStatus {
   NOT_FOUND_HISTORY_CHAT(false, HttpStatus.NOT_FOUND, 4007, "카드 생성 중 이전 대화기록을 찾을 수 없습니다. id 값을 확인해주세요."),
   INVALID_MUSIC_CHOICE(false, HttpStatus.BAD_REQUEST, 4008, "음악 선택값이 올바른지 확인해주세요."),
   FAIL_FILE_READ(false, HttpStatus.FORBIDDEN, 4009, "파일 업로드에 실패했습니다. 다시 시도해주세요."),
-  INVALID_MEMBER_ID(false, HttpStatus.NOT_FOUND, 40010, "존재하지 않는 회원입니다."),
+  INVALID_MEMBER_ID(false, HttpStatus.NOT_FOUND, 4010, "존재하지 않는 회원입니다."),
   INVALID_PLAYLIST_ID(false, HttpStatus.NOT_FOUND, 4011, "존재하지 않는 플레이리스트입니다."),
   NOT_FOUND_BABY(false, HttpStatus.NOT_FOUND, 4012, "아기를 찾을 수 없습니다"),
   NOT_FOUND_CHARACTER(false, HttpStatus.NOT_FOUND, 4013, "캐릭터를 찾을 수 없습니다"),


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

[#92](https://github.com/KUIT-AGARANG/Agarang-Backend/issues/92)


<br/>

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- MusicSaveUtil은 `장르,분위기,음악`을 인자값으로 받아서 해당하는 `playlistId`를 List형식으로 반환합니다.
- `Util`이용하여 `return`된 `PlaylistId`을 이용하여 `memoryplaylist`에 저장합니다.




<br/>

### 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/35f59a78-31ff-458e-a19b-4a0e69bfc8b8)
<br/>

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

@JGoo99  AIService TODO 쪽에 코드를 추가했는데 문제가 있으면 말씀해주세요!