### PR TITLE
Hot fix/webhook permitall

### DIFF
--- a/src/main/java/com/kuit/agarang/domain/login/filter/JWTFilter.java
+++ b/src/main/java/com/kuit/agarang/domain/login/filter/JWTFilter.java
@@ -19,8 +19,6 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -28,16 +26,10 @@ public class JWTFilter extends OncePerRequestFilter {
 
   private final JWTUtil jwtUtil;
 
-  private static final List<String> EXCLUDED_URIS = Arrays.asList(
-    "/reissue",
-    "/api/ai/tts/webhook",
-    "/api/ai/music-gen/webhook"
-  );
-
   @Override
   protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
 
-    if (isExcludedURI(request.getRequestURI())) {
+    if ("/reissue".equals(request.getRequestURI())) {
       filterChain.doFilter(request, response);
       return;
     }
@@ -84,9 +76,5 @@ public class JWTFilter extends OncePerRequestFilter {
 
     log.info("JWT Filter Success");
     filterChain.doFilter(request, response);
-  }
-
-  private boolean isExcludedURI(String requestURI) {
-    return EXCLUDED_URIS.contains(requestURI);
   }
 }

--- a/src/main/java/com/kuit/agarang/domain/login/filter/JWTFilter.java
+++ b/src/main/java/com/kuit/agarang/domain/login/filter/JWTFilter.java
@@ -19,6 +19,8 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -26,10 +28,16 @@ public class JWTFilter extends OncePerRequestFilter {
 
   private final JWTUtil jwtUtil;
 
+  private static final List<String> EXCLUDED_URIS = Arrays.asList(
+    "/reissue",
+    "/api/ai/tts/webhook",
+    "/api/ai/music-gen/webhook"
+  );
+
   @Override
   protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
 
-    if ("/reissue".equals(request.getRequestURI())) {
+    if (isExcludedURI(request.getRequestURI())) {
       filterChain.doFilter(request, response);
       return;
     }
@@ -46,6 +54,7 @@ public class JWTFilter extends OncePerRequestFilter {
     }
 
     if (accessToken == null) {
+      SecurityContextHolder.getContext().setAuthentication(null);
       filterChain.doFilter(request, response);
       return;
     }
@@ -75,5 +84,9 @@ public class JWTFilter extends OncePerRequestFilter {
 
     log.info("JWT Filter Success");
     filterChain.doFilter(request, response);
+  }
+
+  private boolean isExcludedURI(String requestURI) {
+    return EXCLUDED_URIS.contains(requestURI);
   }
 }

--- a/src/main/java/com/kuit/agarang/global/common/config/SecurityConfig.java
+++ b/src/main/java/com/kuit/agarang/global/common/config/SecurityConfig.java
@@ -52,7 +52,7 @@ public class SecurityConfig {
         .authorizeHttpRequests((auth) -> auth
             .requestMatchers(
                 "/", "/env", "/api-json/**", "/api-docs", "/swagger-ui/**").permitAll()
-            .requestMatchers("/oauth2/**", "/reissue").permitAll()
+            .requestMatchers("/oauth2/**", "/login/**","/reissue").permitAll()
             .requestMatchers("/api/ai/music-gen/webhook", "/api/ai/tts/webhook").permitAll()
             .anyRequest().hasRole("USER")
         )

--- a/src/main/java/com/kuit/agarang/global/common/config/SecurityConfig.java
+++ b/src/main/java/com/kuit/agarang/global/common/config/SecurityConfig.java
@@ -51,11 +51,10 @@ public class SecurityConfig {
     http
         .authorizeHttpRequests((auth) -> auth
             .requestMatchers(
-                "/", "/env", "/api-json/**", "/api-docs", "/swagger-ui/**",
-                "/oauth2/**")
-            .permitAll()
-            .requestMatchers("/reissue").permitAll()
-            .anyRequest().permitAll() // TODO : 인가 구현 후 수정
+                "/", "/env", "/api-json/**", "/api-docs", "/swagger-ui/**").permitAll()
+            .requestMatchers("/oauth2/**", "/reissue").permitAll()
+            .requestMatchers("/api/ai/music-gen/webhook", "/api/ai/tts/webhook").permitAll()
+            .anyRequest().hasRole("USER")
         )
         .oauth2Login(oauth2 -> oauth2
             .userInfoEndpoint(endpoint -> endpoint.userService(customOAuth2UserService))


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

#### ✨ 로그인 리다이렉팅

쿠키에 `ACCESS` 가 없으면 세션 인증 정보를 지웁니다.
따라서 USER 권한이 필요한 uri 요청 시에는 `UsernamePasswordAuthenticationFilter` 에서 권한 인증에 실패하고, 시큐리티 기본 설정에 의해 로그인 페이지로 리다이렉트 됩니다.

> ACCESS 쿠키를 삭제한 경우)

![스크린샷 2024-08-18 오전 7 32 13](https://github.com/user-attachments/assets/31ba40fb-0075-4044-9ab7-dcbe1ec6028d)

![스크린샷 2024-08-18 오전 7 28 21](https://github.com/user-attachments/assets/7fe2c9f3-db6b-4e13-a288-1a6e0feb96a7)


<br/>

#### ✨ 웹훅 permit-all

처음 webhook 시도 시 302 리다이렉트가 발생했습니다.

jwtFilter 에서 Context 를 삭제해서 문제가 생겼다고 판단하고

tts, music-gen 웹훅 uri 를 `jwtFilter` 에서 무시하도록 설정하였으나,

이후 다시 테스트해봤을 때 jwt 필터를 거쳐도 문제가 없어 다시 원래대로 수정했습니다.

현재는 securityConfig 에 uri 를 추가한 상태로 문제없이 동작합니다.

![스크린샷 2024-08-18 오전 7 00 00](https://github.com/user-attachments/assets/78e374cc-8861-4e11-8bc7-cb118d131d64)