### PR TITLE
[Chore] 24 시간 이상 사용하지 않는 도커 이미지 삭제

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -121,3 +121,4 @@ jobs:
             sudo docker network connect my-network ${{env.TARGET_UPSTREAM}}
             sudo docker stop ${{env.CURRENT_UPSTREAM}}
             sudo docker rm ${{env.CURRENT_UPSTREAM}}
+            sudo docker image prune -a --force --filter "until=24h"


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#120 

<br/>

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

사용하지 않는 도커 이미지는 디스크에 저장되어 보관됩니다.

미리미리 삭제하지 않으면 용량부족으로 빌드(재배포) 에 실패합니다.

따라서 24시간 이상 사용하지 않는 이미지는 삭제하도록 합니다.

[트러블슈팅](https://goo99.notion.site/CICD-186bbccba32a45178b6252ab0d5e1d2b) 링크 남깁니다!