### PR TITLE
fix: tts get방식 & historyMessage 저장 방식

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -121,3 +121,4 @@ jobs:
             sudo docker network connect my-network ${{env.TARGET_UPSTREAM}}
             sudo docker stop ${{env.CURRENT_UPSTREAM}}
             sudo docker rm ${{env.CURRENT_UPSTREAM}}
+            sudo docker image prune -a --force --filter "until=24h"

--- a/src/main/java/com/kuit/agarang/domain/ai/service/AIService.java
+++ b/src/main/java/com/kuit/agarang/domain/ai/service/AIService.java
@@ -1,7 +1,12 @@
 package com.kuit.agarang.domain.ai.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.kuit.agarang.domain.ai.model.dto.*;
+import com.kuit.agarang.domain.ai.model.dto.MemoryTextInfo;
+import com.kuit.agarang.domain.ai.model.dto.MusicAnswer;
+import com.kuit.agarang.domain.ai.model.dto.MusicInfo;
+import com.kuit.agarang.domain.ai.model.dto.QuestionResponse;
+import com.kuit.agarang.domain.ai.model.dto.QuestionResult;
+import com.kuit.agarang.domain.ai.model.dto.TextAnswer;
 import com.kuit.agarang.domain.ai.model.dto.gpt.GPTChat;
 import com.kuit.agarang.domain.ai.model.dto.gpt.GPTImageDescription;
 import com.kuit.agarang.domain.ai.model.dto.gpt.GPTMessage;
@@ -14,12 +19,10 @@ import com.kuit.agarang.domain.member.model.entity.Member;
 import com.kuit.agarang.domain.member.repository.MemberRepository;
 import com.kuit.agarang.domain.memory.model.entity.Hashtag;
 import com.kuit.agarang.domain.memory.model.entity.Memory;
-import com.kuit.agarang.domain.memory.repository.HashTagRepository;
 import com.kuit.agarang.domain.memory.repository.MemoryRepository;
 import com.kuit.agarang.domain.playlist.model.entity.MemoryPlaylist;
 import com.kuit.agarang.domain.playlist.model.entity.Playlist;
 import com.kuit.agarang.domain.playlist.repository.MemoryPlaylistRepository;
-import com.kuit.agarang.domain.playlist.repository.PlaylistRepository;
 import com.kuit.agarang.domain.playlist.util.MusicSaveUtil;
 import com.kuit.agarang.global.common.exception.exception.BusinessException;
 import com.kuit.agarang.global.common.exception.exception.OpenAPIException;
@@ -29,14 +32,13 @@ import com.kuit.agarang.global.s3.model.dto.S3File;
 import com.kuit.agarang.global.s3.utils.S3FileUtil;
 import com.kuit.agarang.global.s3.utils.S3Util;
 import jakarta.transaction.Transactional;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.Nullable;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.util.List;
 
 @Slf4j
 @Service
@@ -46,26 +48,21 @@ public class AIService {
   private final GPTUtil gptUtil;
   private final GPTPromptUtil promptUtil;
   private final GPTChatService gptChatService;
+  private final MusicGenService musicGenService;
   private final TypecastService typecastService;
 
   private final S3Util s3Util;
   private final S3FileUtil s3FileUtil;
+  private final MusicSaveUtil musicSaveUtil;
 
   private final RedisService redisService;
   private final ObjectMapper objectMapper;
 
   private final MemoryRepository memoryRepository;
   private final MemberRepository memberRepository;
-
-
-  private final MusicGenService musicGenService;
-  private final HashTagRepository hashTagRepository;
-
-  private final MusicSaveUtil musicSaveUtil;
   private final MemoryPlaylistRepository memoryPlaylistRepository;
-  private final PlaylistRepository playlistRepository;
 
-  public QuestionResponse getFirstQuestion(MultipartFile image) throws Exception {
+  public QuestionResponse getFirstQuestion(MultipartFile image) {
     S3File convertedImage = s3FileUtil.convert(image);
 
     // image -> gpt -> 노래제목, 해시태그 생성
@@ -79,7 +76,7 @@ public class AIService {
     String question = gptUtil.getGPTAnswer(questionChat);
 
     // 질문1 -> tts -> 오디오 변환
-    String questionAudioUrl = getAudioUrl(question);
+    String typecastAudioId = typecastService.getAudioDownloadUrl(question);
 
     // 대화기록 저장 및 임시저장이 필요한 데이터 저장
     String redisKey = questionChat.getGptResponse().getId();
@@ -91,16 +88,14 @@ public class AIService {
         .historyMessages(historyMessage)
         .build());
 
-    logChat(historyMessage);
     return new QuestionResponse(QuestionResult.builder()
       .id(redisKey)
       .text(question)
-      .audioUrl(questionAudioUrl)
+      .audioUrl(getAudioUrl(typecastAudioId))
       .build());
   }
 
-  private @Nullable String getAudioUrl(String question) {
-    String typecastAudioId = typecastService.getAudioDownloadUrl(question);
+  private @Nullable String getAudioUrl(String typecastAudioId) {
     String questionAudioUrl = null;
     if (checkEntityExistence(typecastAudioId)) {
       questionAudioUrl = redisService.get(typecastAudioId, String.class)
@@ -117,15 +112,15 @@ public class AIService {
     GPTChat chat = gptChatService.chatWithHistory(chatHistory.getHistoryMessages(), answer.getText(), 0L);
     String question = gptUtil.getGPTAnswer(chat);
 
-    String questionAudioUrl = getAudioUrl(question);
+    String typecastAudioId = typecastService.getAudioDownloadUrl(question);
 
-    logChat(gptUtil.createHistoryMessage(chat));
+    gptUtil.addHistoryMessage(chatHistory, gptUtil.getResponseMessage(chat));
     redisService.save(answer.getId(), chatHistory);
 
     return new QuestionResponse(QuestionResult.builder()
       .id(answer.getId())
       .text(question)
-      .audioUrl(questionAudioUrl)
+      .audioUrl(getAudioUrl(typecastAudioId))
       .build());
   }
 
@@ -133,9 +128,9 @@ public class AIService {
     GPTChatHistory chatHistory = redisService.get(answer.getId(), GPTChatHistory.class)
       .orElseThrow(() -> new OpenAPIException(BaseResponseStatus.NOT_FOUND_HISTORY_CHAT));
 
-    chatHistory.getHistoryMessages().add(gptUtil.createTextMessage(answer.getText()));
-    logChat(chatHistory.getHistoryMessages());
+    gptUtil.addHistoryMessage(chatHistory, gptUtil.createTextMessage(answer.getText()));
     redisService.save(answer.getId(), chatHistory);
+    logChat(chatHistory.getHistoryMessages());
   }
 
   @Async
@@ -149,7 +144,7 @@ public class AIService {
     GPTChat chat = gptChatService.chatWithHistory(chatHistory.getHistoryMessages(), prompt, 0L);
 
     chatHistory.setMemoryText(gptUtil.getGPTAnswer(chat));
-    logChat(gptUtil.createHistoryMessage(chat));
+    gptUtil.addHistoryMessage(chatHistory, gptUtil.getResponseMessage(chat));
     redisService.save(gptChatHistoryId, chatHistory);
   }
 
@@ -177,14 +172,12 @@ public class AIService {
     String prompt = promptUtil.createMusicGenPrompt(chatHistory.getImageDescription(), chatHistory.getMusicInfo());
     GPTChat chat = gptChatService.chat(GPTSystemRole.MUSIC_PROMPT_ENGINEER, prompt, 1L, true);
     String musicGenPrompt = gptUtil.parseJson(chat, "prompt");
-    logChat(gptUtil.createHistoryMessage(chat));
-    log.info("musicGenPrompt {}", musicGenPrompt);
+    log.info("musicGenPrompt : {}", musicGenPrompt);
 
     prompt = promptUtil.createMusicTitlePrompt(musicGenPrompt, chatHistory.getMusicInfo());
     chat = gptChatService.chat(GPTSystemRole.MUSIC_TITLE_WRITER, prompt, 1L, true);
     String musicTitle = gptUtil.parseJson(chat, "music_name");
-    logChat(gptUtil.createHistoryMessage(chat));
-    log.info(musicTitle);
+    log.info("musicTitle : {}", musicTitle);
 
     String musicGenId = musicGenService.getMusic(musicGenPrompt);
     S3File image = s3Util.upload(chatHistory.getImage());
@@ -223,12 +216,14 @@ public class AIService {
       .orElseThrow(() -> new BusinessException(BaseResponseStatus.NOT_FOUND_MEMBER));
   }
 
-  // TODO : redis 트리거 전환
   public boolean checkEntityExistence(String key) {
+    if (redisService.existsByKey(key)) {
+      return true;
+    }
     try {
       for (int i = 1; i < 3; i++) {
         log.info("{}차 대기", i);
-        Thread.sleep(1500);
+        Thread.sleep(1000);
 
         if (redisService.existsByKey(key)) {
           return true;

--- a/src/main/java/com/kuit/agarang/domain/ai/utils/GPTUtil.java
+++ b/src/main/java/com/kuit/agarang/domain/ai/utils/GPTUtil.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.kuit.agarang.domain.ai.model.dto.gpt.GPTChat;
 import com.kuit.agarang.domain.ai.model.dto.gpt.GPTContent;
 import com.kuit.agarang.domain.ai.model.dto.gpt.GPTMessage;
+import com.kuit.agarang.domain.ai.model.entity.cache.GPTChatHistory;
 import com.kuit.agarang.domain.ai.model.enums.GPTRole;
 import com.kuit.agarang.domain.ai.model.enums.GPTSystemRole;
 import com.kuit.agarang.global.common.exception.exception.OpenAPIException;
@@ -48,6 +49,10 @@ public class GPTUtil {
     return historyMessage;
   }
 
+  public void addHistoryMessage(GPTChatHistory chatHistory, GPTMessage responseMessage) {
+    chatHistory.getHistoryMessages().add(responseMessage);
+  }
+
   public String getGPTAnswer(GPTChat gptChat) {
     try {
       return (String) getResponseMessage(gptChat).getContent();
@@ -56,7 +61,7 @@ public class GPTUtil {
     }
   }
 
-  private GPTMessage getResponseMessage(GPTChat gptChat) {
+  public GPTMessage getResponseMessage(GPTChat gptChat) {
     try {
       return gptChat.getGptResponse().getChoices().get(0).getMessage();
     } catch (NullPointerException e) {


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 👾 사용하지 않는 임포트문 제거

<br/>

### 👾 tts 오디오 url 가져오는 방식 변경

`음성 생성 요청`과 `웹훅` 사이에 redis 저장 로직을 수행합니다.

첫 요청 시 바로 sleep 하지 않고 먼저 exists 를 체크합니다.

대기 시간은 1초로 변경합니다.

<br/>

### 👾 history message 저장 방식 변경

첫 이미지 등록 시 같은 질문이 두번 발생하는 이유가 history message 저장 방식에 오류가 있다고 판단하여 수정합니다.
(기존 방식은 메시지가 정상적으로 로깅만 되고 실제 레디스에는 저장되지 않았음.)

<br/>

### 👾 (추가) 사용하지않는 도커 이미지 삭제

#120 

사용하지 않는 도커 이미지는 디스크에 저장되어 보관됩니다.

미리미리 삭제하지 않으면 용량부족으로 빌드(재배포) 에 실패합니다.

따라서 24시간 이상 사용하지 않는 이미지는 삭제하도록 합니다.

[트러블슈팅](https://goo99.notion.site/CICD-186bbccba32a45178b6252ab0d5e1d2b) 링크 남깁니다!

<br/>

## To Reviewers

이전 pr 을 머지한다는게 닫아버렸나봅니다..!
1줄 수정이어서 이번 pr에 같이 올립니다.
